### PR TITLE
Возможность показывать любые дополнительные свойства выбранного предмета

### DIFF
--- a/ogsr_engine/xrGame/ui/UIItemInfo.cpp
+++ b/ogsr_engine/xrGame/ui/UIItemInfo.cpp
@@ -229,7 +229,7 @@ void CUIItemInfo::TryAddCustomInfo(CPhysicsShellHolder& obj)
 {
 	UICustomParams->DetachAll();
 
-	if (!!pSettings->line_exist("engine_callbacks", "ui_item_info_callback"))
+	if (pSettings->line_exist("engine_callbacks", "ui_item_info_callback"))
 	{
 		const LPCSTR callback = pSettings->r_string("engine_callbacks", "ui_item_info_callback");
 

--- a/ogsr_engine/xrGame/ui/UIItemInfo.h
+++ b/ogsr_engine/xrGame/ui/UIItemInfo.h
@@ -10,7 +10,7 @@ class CUIWpnParams;
 class CUIArtefactParams;
 class CPhysicsShellHolder;
 
-extern const char * const 		fieldsCaptionColor;
+//extern const char * const 		fieldsCaptionColor;
 
 class CUIItemInfo: public CUIWindow
 {
@@ -31,8 +31,10 @@ public:
 	void				Init				(float x, float y, float width, float height, LPCSTR xml_name);
 	void				Init				(LPCSTR xml_name);
 	void				InitItem			(CInventoryItem* pInvItem);
-	void				TryAddWpnInfo		(CPhysicsShellHolder& obj/*const shared_str& wpn_section*/);
-	void				TryAddArtefactInfo	(const shared_str& af_section);
+
+	void				TryAddWpnInfo		(CPhysicsShellHolder& obj);
+	void				TryAddArtefactInfo(const shared_str& af_section);
+	void				TryAddCustomInfo(CPhysicsShellHolder& obj);
 
 	virtual void		Draw				();
 	bool				m_b_force_drawing;
@@ -44,6 +46,7 @@ public:
 	CUIProgressBar*		UICondProgresBar;
 	CUIWpnParams*		UIWpnParams;
 	CUIArtefactParams*	UIArtefactParams;
+	CUIWindow*		UICustomParams;
 
 	Fvector2			UIItemImageSize; 
 	CUIStatic*			UIItemImage;


### PR DESCRIPTION
Добавил возможность показывать любые дополнительные свойства выбранного предмета в инвентарях. Работает через вызов движком lua функтора в который передается выбраны предмет и UIStatic на который можно добавить все что нужно для отображения.

Для включение нужно добавить в system.ltx
```
[engine_callbacks]
ui_item_info_callback=ui_custom_params.try_add_custom
```
**ui_custom_params.try_add_custom** - скриптовый метод с сигнатурой:
**try_add_custom(obj, wnd)**

Перед вызовом статик wnd всегда очищается движком.
Если метод вернул true - статик будет показан в свойствах предмета, false - нет.

Пример реализации скрипта для отображения свойств eatable_item для ТЧ  https://gist.github.com/joye-ramone/a9c9b6dfc43202b46bc41bde08b0082d
