### PR TITLE
Доработки для UI callbacks

### DIFF
--- a/ogsr_engine/xrGame/ScriptXMLInit.cpp
+++ b/ogsr_engine/xrGame/ScriptXMLInit.cpp
@@ -23,13 +23,16 @@ using namespace luabind;
 
 void _attach_child(CUIWindow* _child, CUIWindow* _parent)
 {
-	if(!_parent)	return;
+	if(!_parent)	
+		return;
+
 	CUIScrollView* _parent_scroll = smart_cast<CUIScrollView*>(_parent);
 	if(_parent_scroll)
 		_parent_scroll->AddWindow	(_child, true);
 	else
 		_parent->AttachChild		(_child);
 }
+
 CScriptXmlInit::CScriptXmlInit(){
 
 }
@@ -47,10 +50,17 @@ void CScriptXmlInit::ParseFile(LPCSTR xml_file){
 	m_xml.Init(CONFIG_PATH, UI_PATH, xml_file);
 }
 
+void CScriptXmlInit::ParseShTexInfo(LPCSTR xml_file){
+	CUITextureMaster::ParseShTexInfo(xml_file);
+}
+
 void CScriptXmlInit::InitWindow(LPCSTR path, int index, CUIWindow* pWnd){
 	CUIXmlInit::InitWindow(m_xml, path, index, pWnd);
 }
 
+void CScriptXmlInit::InitAutoStaticGroup(LPCSTR path, CUIWindow* pWnd){
+	CUIXmlInit::InitAutoStaticGroup(m_xml, path, 0, pWnd);
+}
 
 CUIFrameWindow*	CScriptXmlInit::InitFrame(LPCSTR path, CUIWindow* parent){
 	CUIFrameWindow* pWnd = xr_new<CUIFrameWindow>();
@@ -108,11 +118,6 @@ CUIStatic* CScriptXmlInit::InitStatic(LPCSTR path, CUIWindow* parent){
 	return pWnd;
 }
 
-void CScriptXmlInit::InitAutoStaticGroup(LPCSTR path, CUIWindow* pWnd)
-{
-	CUIXmlInit::InitAutoStaticGroup(m_xml, path, 0, pWnd);
-}
-
 CUIStatic* CScriptXmlInit::InitAnimStatic(LPCSTR path, CUIWindow* parent){
 	CUIAnimatedStatic* pWnd = xr_new<CUIAnimatedStatic>();
 	CUIXmlInit::InitAnimatedStatic(m_xml, path, 0, pWnd);
@@ -130,7 +135,6 @@ CUIScrollView* CScriptXmlInit::InitScrollView(LPCSTR path, CUIWindow* parent){
 //.	if(parent) parent->AttachChild(pWnd);
 	return pWnd;
 }
-
 
 
 CUICheckButton* CScriptXmlInit::InitCheck(LPCSTR path, CUIWindow* parent){
@@ -214,10 +218,6 @@ CUITabControl* CScriptXmlInit::InitTab(LPCSTR path, CUIWindow* parent){
 	_attach_child(pWnd, parent);
 //.	if(parent) parent->AttachChild(pWnd);
 	return pWnd;	
-}
-
-void CScriptXmlInit::ParseShTexInfo(LPCSTR xml_file){
-	CUITextureMaster::ParseShTexInfo(xml_file);
 }
 
 CUIMMShniaga* CScriptXmlInit::InitMMShniaga(LPCSTR path, CUIWindow* parent){

--- a/ogsr_engine/xrGame/ScriptXMLInit.h
+++ b/ogsr_engine/xrGame/ScriptXMLInit.h
@@ -39,8 +39,9 @@ public:
 
 	void ParseFile		(LPCSTR xml_file);
 	void ParseShTexInfo	(LPCSTR xml_file);
+
 	void InitWindow		(LPCSTR path, int index, CUIWindow* pWnd);
-	//void InitList		(LPCSTR path, int index, CUIListWnd* pWnd);
+	void InitAutoStaticGroup(LPCSTR path, CUIWindow* pWnd);
 
 	CUIListWnd*			InitList(LPCSTR path, CUIWindow* parent);
 	CUIFrameWindow*		InitFrame(LPCSTR path, CUIWindow* parent);
@@ -63,7 +64,7 @@ public:
 	CUIWindow*			InitKeyBinding(LPCSTR path, CUIWindow* parent);
 	CUIScrollView*		InitScrollView(LPCSTR path, CUIWindow* parent);
 	CUIProgressBar*		InitProgressBar(LPCSTR path, CUIWindow* parent);
-	void				InitAutoStaticGroup(LPCSTR path, CUIWindow* pWnd);
+
 protected:
 	CUIXml	m_xml;
 };

--- a/ogsr_engine/xrGame/ui/UIInventoryWnd.cpp
+++ b/ogsr_engine/xrGame/ui/UIInventoryWnd.cpp
@@ -50,7 +50,6 @@ CUIInventoryWnd::CUIInventoryWnd() :
 
 	g_pInvWnd							= this;	
 	m_b_need_reinit						= false;
-	m_b_need_update_stats = true;
 	Hide								();	
 }
 
@@ -295,14 +294,9 @@ void CUIInventoryWnd::Update()
 		sprintf_s							(sMoney,"%d RU", _money);
 		UIMoneyWnd.SetText				(sMoney);
 
-		if (m_b_need_update_stats)
-		{
-			// update outfit parameters
-			CCustomOutfit* outfit = smart_cast<CCustomOutfit*>(pOurInvOwner->inventory().m_slots[OUTFIT_SLOT].m_pIItem);
-			UIOutfitInfo.Update(outfit);
-
-			m_b_need_update_stats = false;
-		}
+		// update outfit parameters
+		CCustomOutfit* outfit = smart_cast<CCustomOutfit*>(pOurInvOwner->inventory().m_slots[OUTFIT_SLOT].m_pIItem);
+		UIOutfitInfo.Update(outfit);
 	}
 
 	UIStaticTimeString.SetText(*InventoryUtilities::GetGameTimeAsString(InventoryUtilities::etpTimeToMinutes));
@@ -434,7 +428,6 @@ void	CUIInventoryWnd::SendEvent_Item2Slot			(PIItem	pItem)
 	P.w_u16							(pItem->object().ID());
 	pItem->object().u_EventSend		(P);
 	g_pInvWnd->PlaySnd				(eInvItemToSlot);
-	m_b_need_update_stats = true;
 };
 
 void	CUIInventoryWnd::SendEvent_Item2Belt			(PIItem	pItem)
@@ -444,7 +437,6 @@ void	CUIInventoryWnd::SendEvent_Item2Belt			(PIItem	pItem)
 	P.w_u16							(pItem->object().ID());
 	pItem->object().u_EventSend		(P);
 	g_pInvWnd->PlaySnd				(eInvItemToBelt);
-	m_b_need_update_stats = true;
 };
 
 void	CUIInventoryWnd::SendEvent_Item2Ruck			(PIItem	pItem)
@@ -454,7 +446,6 @@ void	CUIInventoryWnd::SendEvent_Item2Ruck			(PIItem	pItem)
 	P.w_u16							(pItem->object().ID());
 	pItem->object().u_EventSend		(P);
 	g_pInvWnd->PlaySnd				(eInvItemToRuck);
-	m_b_need_update_stats = true;
 };
 
 void	CUIInventoryWnd::SendEvent_Item_Drop(PIItem	pItem)
@@ -469,7 +460,6 @@ void	CUIInventoryWnd::SendEvent_Item_Drop(PIItem	pItem)
 		pItem->object().u_EventSend(P);
 	}
 	g_pInvWnd->PlaySnd				(eInvDropItem);
-	m_b_need_update_stats = true;
 };
 
 void	CUIInventoryWnd::SendEvent_Item_Eat			(PIItem	pItem)

--- a/ogsr_engine/xrGame/ui/UIInventoryWnd.cpp
+++ b/ogsr_engine/xrGame/ui/UIInventoryWnd.cpp
@@ -50,6 +50,7 @@ CUIInventoryWnd::CUIInventoryWnd() :
 
 	g_pInvWnd							= this;	
 	m_b_need_reinit						= false;
+	m_b_need_update_stats = true;
 	Hide								();	
 }
 
@@ -288,14 +289,20 @@ void CUIInventoryWnd::Update()
 
 		CInventoryOwner* pOurInvOwner	= smart_cast<CInventoryOwner*>(pEntityAlive);
 		u32 _money						= pOurInvOwner->get_money();
+
 		// update money
 		string64						sMoney;
 		sprintf_s							(sMoney,"%d RU", _money);
 		UIMoneyWnd.SetText				(sMoney);
 
-		// update outfit parameters
-		CCustomOutfit* outfit			= smart_cast<CCustomOutfit*>(pOurInvOwner->inventory().m_slots[OUTFIT_SLOT].m_pIItem);		
-		UIOutfitInfo.Update				(outfit);		
+		if (m_b_need_update_stats)
+		{
+			// update outfit parameters
+			CCustomOutfit* outfit = smart_cast<CCustomOutfit*>(pOurInvOwner->inventory().m_slots[OUTFIT_SLOT].m_pIItem);
+			UIOutfitInfo.Update(outfit);
+
+			m_b_need_update_stats = false;
+		}
 	}
 
 	UIStaticTimeString.SetText(*InventoryUtilities::GetGameTimeAsString(InventoryUtilities::etpTimeToMinutes));
@@ -427,6 +434,7 @@ void	CUIInventoryWnd::SendEvent_Item2Slot			(PIItem	pItem)
 	P.w_u16							(pItem->object().ID());
 	pItem->object().u_EventSend		(P);
 	g_pInvWnd->PlaySnd				(eInvItemToSlot);
+	m_b_need_update_stats = true;
 };
 
 void	CUIInventoryWnd::SendEvent_Item2Belt			(PIItem	pItem)
@@ -436,6 +444,7 @@ void	CUIInventoryWnd::SendEvent_Item2Belt			(PIItem	pItem)
 	P.w_u16							(pItem->object().ID());
 	pItem->object().u_EventSend		(P);
 	g_pInvWnd->PlaySnd				(eInvItemToBelt);
+	m_b_need_update_stats = true;
 };
 
 void	CUIInventoryWnd::SendEvent_Item2Ruck			(PIItem	pItem)
@@ -444,8 +453,8 @@ void	CUIInventoryWnd::SendEvent_Item2Ruck			(PIItem	pItem)
 	pItem->object().u_EventGen		(P, GEG_PLAYER_ITEM2RUCK, pItem->object().H_Parent()->ID());
 	P.w_u16							(pItem->object().ID());
 	pItem->object().u_EventSend		(P);
-
 	g_pInvWnd->PlaySnd				(eInvItemToRuck);
+	m_b_need_update_stats = true;
 };
 
 void	CUIInventoryWnd::SendEvent_Item_Drop(PIItem	pItem)
@@ -460,6 +469,7 @@ void	CUIInventoryWnd::SendEvent_Item_Drop(PIItem	pItem)
 		pItem->object().u_EventSend(P);
 	}
 	g_pInvWnd->PlaySnd				(eInvDropItem);
+	m_b_need_update_stats = true;
 };
 
 void	CUIInventoryWnd::SendEvent_Item_Eat			(PIItem	pItem)
@@ -470,7 +480,6 @@ void	CUIInventoryWnd::SendEvent_Item_Eat			(PIItem	pItem)
 	P.w_u16							(pItem->object().ID());
 	pItem->object().u_EventSend		(P);
 };
-
 
 void CUIInventoryWnd::BindDragDropListEnents(CUIDragDropListEx* lst)
 {

--- a/ogsr_engine/xrGame/ui/UIInventoryWnd.h
+++ b/ogsr_engine/xrGame/ui/UIInventoryWnd.h
@@ -24,6 +24,7 @@ class CUIInventoryWnd: public CUIDialogWnd
 private:
 	typedef CUIDialogWnd	inherited;
 	bool					m_b_need_reinit;
+	bool					m_b_need_update_stats;
 public:
 							CUIInventoryWnd				();
 	virtual					~CUIInventoryWnd			();

--- a/ogsr_engine/xrGame/ui/UIInventoryWnd.h
+++ b/ogsr_engine/xrGame/ui/UIInventoryWnd.h
@@ -24,7 +24,6 @@ class CUIInventoryWnd: public CUIDialogWnd
 private:
 	typedef CUIDialogWnd	inherited;
 	bool					m_b_need_reinit;
-	bool					m_b_need_update_stats;
 public:
 							CUIInventoryWnd				();
 	virtual					~CUIInventoryWnd			();

--- a/ogsr_engine/xrGame/ui/UIItemInfo.cpp
+++ b/ogsr_engine/xrGame/ui/UIItemInfo.cpp
@@ -26,7 +26,6 @@ CUIItemInfo::CUIItemInfo()
 	UIDesc						= NULL;
 	UIWpnParams					= NULL;
 	UIArtefactParams			= NULL;
-	UICustomParams = NULL;
 	UIName						= NULL;
 	m_pInvItem					= NULL;
 	m_b_force_drawing			= false;
@@ -36,7 +35,6 @@ CUIItemInfo::~CUIItemInfo()
 {
 	xr_delete					(UIWpnParams);
 	xr_delete					(UIArtefactParams);
-	xr_delete					(UICustomParams);
 }
 
 void CUIItemInfo::Init(LPCSTR xml_name){
@@ -103,9 +101,7 @@ void CUIItemInfo::Init(LPCSTR xml_name){
 
 		UIArtefactParams				= xr_new<CUIArtefactParams>();
 		UIArtefactParams->InitFromXml	(uiXml);
-
-		UICustomParams = xr_new<CUIWindow>();
-
+		
 		UIDesc							= xr_new<CUIScrollView>(); 
 		AttachChild						(UIDesc);		
 		UIDesc->SetAutoDelete			(true);
@@ -227,18 +223,12 @@ void CUIItemInfo::TryAddArtefactInfo(const shared_str& af_section)
 
 void CUIItemInfo::TryAddCustomInfo(CPhysicsShellHolder& obj)
 {
-	UICustomParams->DetachAll();
-
 	if (pSettings->line_exist("engine_callbacks", "ui_item_info_callback"))
 	{
 		const LPCSTR callback = pSettings->r_string("engine_callbacks", "ui_item_info_callback");
-
-		if (luabind::functor<bool> lua_function; ai().script_engine().functor(callback, lua_function))
+		if (luabind::functor<void> lua_function; ai().script_engine().functor(callback, lua_function))
 		{
-			if (lua_function(obj.lua_game_object(), UICustomParams))
-			{
-				UIDesc->AddWindow(UICustomParams, false);
-			}
+			lua_function(UIDesc, obj.lua_game_object());
 		}
 	}
 }

--- a/ogsr_engine/xrGame/ui/UIItemInfo.h
+++ b/ogsr_engine/xrGame/ui/UIItemInfo.h
@@ -46,7 +46,6 @@ public:
 	CUIProgressBar*		UICondProgresBar;
 	CUIWpnParams*		UIWpnParams;
 	CUIArtefactParams*	UIArtefactParams;
-	CUIWindow*		UICustomParams;
 
 	Fvector2			UIItemImageSize; 
 	CUIStatic*			UIItemImage;

--- a/ogsr_engine/xrGame/ui/UIOutfitInfo.h
+++ b/ogsr_engine/xrGame/ui/UIOutfitInfo.h
@@ -10,7 +10,6 @@ struct ActorRestoreParams;
 
 class CUIOutfitInfo : public CUIWindow
 {
-CCustomOutfit*		m_outfit;
 public:
 					CUIOutfitInfo			();
 	virtual			~CUIOutfitInfo			();
@@ -18,7 +17,7 @@ public:
 			void 	Update					(CCustomOutfit* outfit);	
 			void 	InitFromXml				(CUIXml& xml_doc);
 protected:
-	void			SetItem					();
+
 	float			GetArtefactParam		(ActorRestoreParams params, u32 i);
 
 	CUIScrollView*	m_listWnd;

--- a/ogsr_engine/xrGame/ui/UIWindow_script.cpp
+++ b/ogsr_engine/xrGame/ui/UIWindow_script.cpp
@@ -111,6 +111,7 @@ void CUIWindow::script_register(lua_State *L)
 		.def("AttachChild",				&CUIWindow::AttachChild, adopt<2>())
 #endif
 		.def("DetachChild",				&CUIWindow::DetachChild)
+		.def("DetachAll",				&CUIWindow::DetachAll)
 		.def("SetAutoDelete",			&CUIWindow::SetAutoDelete)
 		.def("IsAutoDelete",			&CUIWindow::IsAutoDelete)
 


### PR DESCRIPTION
1. Теперь в **ui_item_info_callback** приходит весь инвентарный UIDesc (xml descr_list). Скрипт решает, что с ним делать и что добавлять. Обновил gist at https://gist.github.com/joye-ramone/a9c9b6dfc43202b46bc41bde08b0082d
2. Добавил новый **ui_actor_info_callback** - вызывается при обновлении outfit_info в инвентаре ГГ. Сигнатура: **try_add_actor_custom(list, obj)**, где list - CUIScrollView (xml outfit_info:scroll_view in inventory_new.xml). obj - текущий костюм ГГ, если нету - nil.
3. Убрал постоянную перерисовку outfit_info в инвентаре ГГ. outfit_info показывает только параметры костюма + артефакты с пояса. Зачем ее обновлять каждый апдейт не ясно. Теперь будет если, любой предмет сделал Item2Slot\Item2Belt\Item2Ruck\Item_Drop.
4. Добавил DetachAll method to CUIWindow export