### PR TITLE
Новые параметры для контрика + правки багов

### DIFF
--- a/ogsr_engine/xrGame/Weapon.cpp
+++ b/ogsr_engine/xrGame/Weapon.cpp
@@ -1066,13 +1066,14 @@ void CWeapon::ZoomDec()
 	float delta, min_zoom_factor;
 	GetZoomData(m_fScopeZoomFactor, delta, min_zoom_factor);
 
-#ifdef OGSE_WPN_ZOOM_SYSTEM
-	m_fZoomFactor -= delta;
-	clamp(m_fZoomFactor, min_zoom_factor, m_fScopeZoomFactor);
-#else
-	m_fZoomFactor += delta;
-	clamp(m_fZoomFactor, m_fScopeZoomFactor, min_zoom_factor);
-#endif
+	if (Core.Features.test(xrCore::Feature::ogse_wpn_zoom_system)) {
+		m_fZoomFactor -= delta;
+		clamp(m_fZoomFactor, min_zoom_factor, m_fScopeZoomFactor);
+	}
+	else {
+		m_fZoomFactor += delta;
+		clamp(m_fZoomFactor, m_fScopeZoomFactor, min_zoom_factor);
+	}
 }
 
 void CWeapon::SpawnAmmo(u32 boxCurr, LPCSTR ammoSect, u32 ParentID) 

--- a/ogsr_engine/xrGame/ai/monsters/controller/controller_psy_hit.h
+++ b/ogsr_engine/xrGame/ai/monsters/controller/controller_psy_hit.h
@@ -24,6 +24,8 @@ class CControllerPsyHit : public CControl_ComCustom<> {
 
 
 	float				m_min_tube_dist;
+	bool				m_disable_camera_effect;
+	bool				m_disable_actor_block;
 
 	// internal flag if weapon was hidden
 	bool				m_blocked;

--- a/ogsr_engine/xrGame/ui/UICarBodyWnd.cpp
+++ b/ogsr_engine/xrGame/ui/UICarBodyWnd.cpp
@@ -626,8 +626,11 @@ bool CUICarBodyWnd::OnKeyboard(int dik, EUIMessages keyboard_action)
 	if (m_b_need_update)
 		return true;
 
-	if (m_pUIPropertiesBox->GetVisible())
-		m_pUIPropertiesBox->OnKeyboard(dik, keyboard_action);
+	if (keyboard_action == WINDOW_KEY_PRESSED)
+	{
+		if (m_pUIPropertiesBox->GetVisible())
+			m_pUIPropertiesBox->OnKeyboard(dik, keyboard_action);
+	}
 
 	if(keyboard_action==WINDOW_KEY_PRESSED && is_binded(kUSE, dik)) 
 	{
@@ -645,7 +648,6 @@ bool CUICarBodyWnd::OnMouse(float x, float y, EUIMessages mouse_action)
 	if (m_b_need_update)
 		return true;
 
-	//вызов дополнительного меню по правой кнопке
 	if (mouse_action == WINDOW_RBUTTON_DOWN)
 	{
 		if (m_pUIPropertiesBox->IsShown())
@@ -655,7 +657,10 @@ bool CUICarBodyWnd::OnMouse(float x, float y, EUIMessages mouse_action)
 		}
 	}
 
-	CUIWindow::OnMouse(x, y, mouse_action);
+	if (CUIWindow::OnMouse(x, y, mouse_action))
+	{
+		return  true;
+	}
 
 	return false;
 }

--- a/ogsr_engine/xrGame/ui/UICellCustomItems.cpp
+++ b/ogsr_engine/xrGame/ui/UICellCustomItems.cpp
@@ -97,12 +97,11 @@ void CUIInventoryCellItem::OnFocusLost()
 
 bool CUIInventoryCellItem::OnMouse(float x, float y, EUIMessages action)
 {
-	inherited::OnMouse(x, y, action);
+	bool r = inherited::OnMouse(x, y, action);
 
-	//if (m_bCursorOverWindow)
 	g_actor->callback(GameObject::eOnCellItemMouse)(object()->object().lua_game_object(), x, y, action);
 
-	return false;
+	return r;
 }
 
 CUIDragItem* CUIInventoryCellItem::CreateDragItem()

--- a/ogsr_engine/xrGame/ui/UIInventoryWnd.cpp
+++ b/ogsr_engine/xrGame/ui/UIInventoryWnd.cpp
@@ -247,7 +247,6 @@ bool CUIInventoryWnd::OnMouse(float x, float y, EUIMessages mouse_action)
 	if(m_b_need_reinit)
 		return true;
 
-	//вызов дополнительного меню по правой кнопке
 	if(mouse_action == WINDOW_RBUTTON_DOWN)
 	{
 		if(UIPropertiesBox.IsShown())

--- a/ogsr_engine/xrGame/ui/UIMainIngameWnd.cpp
+++ b/ogsr_engine/xrGame/ui/UIMainIngameWnd.cpp
@@ -91,39 +91,39 @@ DLL_API CUIMainIngameWnd* GetMainIngameWindow()
 	return NULL;
 }
 
-	CUIStatic * warn_icon_list[8] = { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL };
-	
-	// alpet: для возможности внешнего контроля иконок (используется в NLC6 вместо типичных индикаторов). Никак не влияет на игру для остальных модов.
-	bool __declspec(dllexport) external_icon_ctrl = false;
+CUIStatic * warn_icon_list[8] = { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL };
 
-	// позволяет расцветить иконку или изменить её размер
-	bool __declspec(dllexport) SetupGameIcon(u32 icon, u32 cl, float width, float height)
+// alpet: для возможности внешнего контроля иконок (используется в NLC6 вместо типичных индикаторов). Никак не влияет на игру для остальных модов.
+bool __declspec(dllexport) external_icon_ctrl = false;
+
+// позволяет расцветить иконку или изменить её размер
+bool __declspec(dllexport) SetupGameIcon(u32 icon, u32 cl, float width, float height)
+{
+	CUIMainIngameWnd *window = GetMainIngameWindow();
+	if (!window)
 	{
-		CUIMainIngameWnd *window = GetMainIngameWindow();
-		if (!window)
-		{
-			Msg("SetupGameIcon failed due GetMainIngameWindow() returned NULL");
-			return false;
-		}
-
-		CUIStatic *sIcon = warn_icon_list[icon & 7];
-		
-		if (sIcon)
-		{			
-			if (width > 0 && height > 0)
-			{
-				sIcon->SetWidth (width);
-				sIcon->SetHeight (height);
-				sIcon->SetStretchTexture(cl > 0);
-			}
-			else 
-				window->SetWarningIconColor((CUIMainIngameWnd::EWarningIcons)icon, cl);
-
-			external_icon_ctrl = true;
-			return true;
-		}
+		Msg("SetupGameIcon failed due GetMainIngameWindow() returned NULL");
 		return false;
 	}
+
+	CUIStatic *sIcon = warn_icon_list[icon & 7];
+	
+	if (sIcon)
+	{			
+		if (width > 0 && height > 0)
+		{
+			sIcon->SetWidth (width);
+			sIcon->SetHeight (height);
+			sIcon->SetStretchTexture(cl > 0);
+		}
+		else 
+			window->SetWarningIconColor((CUIMainIngameWnd::EWarningIcons)icon, cl);
+
+		external_icon_ctrl = true;
+		return true;
+	}
+	return false;
+}
 
 CUIMainIngameWnd::CUIMainIngameWnd()
 {
@@ -1134,7 +1134,11 @@ void CUIMainIngameWnd::UpdatePickUpItem	()
 {
 	if (!m_pPickUpItem || !Level().CurrentViewEntity() || Level().CurrentViewEntity()->CLS_ID != CLSID_OBJECT_ACTOR) 
 	{
-//		UIPickUpItemIcon.Show(false);
+		if (UIPickUpItemIcon.IsShown())
+		{
+			UIPickUpItemIcon.Show(false);
+		}
+
 		return;
 	};
 	if (UIPickUpItemIcon.IsShown()) return;

--- a/ogsr_engine/xrGame/ui/UITradeWnd.cpp
+++ b/ogsr_engine/xrGame/ui/UITradeWnd.cpp
@@ -482,7 +482,6 @@ bool CUITradeWnd::OnKeyboard(int dik, EUIMessages keyboard_action)
 
 bool CUITradeWnd::OnMouse(float x, float y, EUIMessages mouse_action)
 {
-	//вызов дополнительного меню по правой кнопке
 	if (mouse_action == WINDOW_RBUTTON_DOWN)
 	{
 		if (m_pUIPropertiesBox->IsShown())

--- a/ogsr_engine/xr_3da/ResourceManager_Loader.cpp
+++ b/ogsr_engine/xr_3da/ResourceManager_Loader.cpp
@@ -96,7 +96,7 @@ void	CResourceManager::OnDeviceCreate	(IReader* F)
 			{
 				if	(B->getDescription().version != desc.version)
 				{
-					Msg			("! Version conflict in shader '%s'",desc.cName);
+					Msg("! Version conflict in shader '%s', expected version: %d, but got: %d", desc.cName, B->getDescription().version, desc.version);
 				}
 
 				chunk->seek		(0);
@@ -112,37 +112,6 @@ void	CResourceManager::OnDeviceCreate	(IReader* F)
 	}
 
 	m_textures_description.Load				();
-/*
-	// Load detail textures association
-	string256		fname;		
-	FS.update_path	(fname,"$game_textures$","textures.ltx");
-	LPCSTR	Iname	= fname;
-	if (FS.exist(Iname))
-	{
-		xr_delete		(m_description);
-		m_description	= xr_new<CInifile>	(Iname);
-		CInifile&	ini	= *m_description;
-		if (ini.section_exist("association"))
-		{
-			CInifile::Sect& 	data = ini.r_section("association");
-			for (CInifile::SectIt I=data.begin(); I!=data.end(); I++)	
-			{
-				texture_detail			D;
-				string256				T;
-				float					s;
-
-				CInifile::Item& item	= *I;
-				sscanf					(*item.second,"%[^,],%f",T,&s);
-
-				//
-				D.T				= xr_strdup				(T);
-				D.cs			= xr_new<cl_dt_scaler>	(s);
-				LPSTR N			= xr_strdup				(*item.first);
-				m_td.insert		(mk_pair(N,D));
-			}
-		}
-	}
-*/
 }
 
 void	CResourceManager::OnDeviceCreate	(LPCSTR shName)


### PR DESCRIPTION
1. Added 2 new parameters to controller config section:
* **tube_disable_camera_effect** - allow to disable actor camera fly during tube attack
* **tube_disable_actor_block** - allow to disable actor control block during tube attack
Both optional and off by default
2. Fixed issue with hide of item properties menu in car body wnd
3. Fixed issue with permanent PickUpItem icon if load game with it visible (from oxygen)
4. Added more details to "Version conflict in shader ... " message