### PR TITLE
Мелкие правки и доработки

### DIFF
--- a/ogsr_engine/xrGame/ActorCondition.cpp
+++ b/ogsr_engine/xrGame/ActorCondition.cpp
@@ -117,7 +117,7 @@ void CActorCondition::UpdateCondition()
 	if (!object().Local() && m_object != Level().CurrentViewEntity())		return;	
 
 	float weight      = object().GetCarryWeight();
-	float max_weight  = weight;
+	float max_weight;
 	if (Core.Features.test(xrCore::Feature::condition_jump_weight_mod))
 		max_weight = object().inventory().GetMaxWeight() + object().ArtefactsAddWeight(false);
 	else

--- a/ogsr_engine/xrGame/ActorCondition.cpp
+++ b/ogsr_engine/xrGame/ActorCondition.cpp
@@ -117,7 +117,12 @@ void CActorCondition::UpdateCondition()
 	if (!object().Local() && m_object != Level().CurrentViewEntity())		return;	
 
 	float weight      = object().GetCarryWeight();
-	float max_weight  = object().inventory().GetMaxWeight() + object().ArtefactsAddWeight( false );
+	float max_weight  = weight;
+	if (Core.Features.test(xrCore::Feature::condition_jump_weight_mod))
+		max_weight = object().inventory().GetMaxWeight() + object().ArtefactsAddWeight(false);
+	else
+		max_weight = object().MaxCarryWeight();
+
 	float weight_coef = weight / max_weight;
 
 	if ((object().mstate_real&mcAnyMove)) {

--- a/ogsr_engine/xrGame/Artifact.cpp
+++ b/ogsr_engine/xrGame/Artifact.cpp
@@ -469,7 +469,12 @@ u16	CArtefact::bone_count_to_synchronize	() const
 	return CInventoryItem::object().PHGetSyncItemsNumber();
 }
 
-
+void CArtefact::GetBriefInfo(xr_string& str_name, xr_string& icon_sect_name, xr_string& str_count)
+{
+	str_name = NameShort();
+	str_count = "";
+	icon_sect_name = *cNameSect();
+}
 
 //---SArtefactActivation----
 SArtefactActivation::SArtefactActivation(CArtefact* af,u32 owner_id)

--- a/ogsr_engine/xrGame/Artifact.h
+++ b/ogsr_engine/xrGame/Artifact.h
@@ -112,6 +112,7 @@ public:
 	virtual void					OnAnimationEnd		(u32 state);
 	virtual bool					IsHidden			()	const	{return GetState()==eHidden;}
 	virtual u16						bone_count_to_synchronize	() const;
+	virtual void					GetBriefInfo(xr_string& str_name, xr_string& icon_sect_name, xr_string& str_count);
 
 	// optimization FAST/SLOW mode
 public:						

--- a/ogsr_engine/xrGame/Bolt.cpp
+++ b/ogsr_engine/xrGame/Bolt.cpp
@@ -98,3 +98,10 @@ u16	CBolt::Initiator				()
 {
 	return m_thrower_id;
 }
+
+void CBolt::GetBriefInfo(xr_string& str_name, xr_string& icon_sect_name, xr_string& str_count)
+{
+	str_name = NameShort();
+	str_count = "";
+	icon_sect_name = *cNameSect();
+}

--- a/ogsr_engine/xrGame/Bolt.h
+++ b/ogsr_engine/xrGame/Bolt.h
@@ -25,6 +25,7 @@ public:
 	virtual bool Useful() const;
     virtual void Destroy();
     virtual void activate_physic_shell	();
+	virtual void GetBriefInfo(xr_string& str_name, xr_string& icon_sect_name, xr_string& str_count);
 
 	virtual BOOL UsedAI_Locations() {return FALSE;}
 	virtual IDamageSource*	cast_IDamageSource			()	{return this;}

--- a/ogsr_engine/xrGame/Weapon.cpp
+++ b/ogsr_engine/xrGame/Weapon.cpp
@@ -61,7 +61,6 @@ CWeapon::CWeapon(LPCSTR name)
 	iAmmoElapsed			= -1;
 	iMagazineSize			= -1;
 	m_ammoType				= 0;
-	m_ammoName				= NULL;
 
 	eHandDependence			= hdNone;
 
@@ -305,10 +304,7 @@ void CWeapon::Load		(LPCSTR section)
 			_GetItem				(S,it,_ammoItem);
 			m_ammoTypes.push_back	(_ammoItem);
 		}
-		m_ammoName = pSettings->r_string(*m_ammoTypes[0],"inv_name_short");
 	}
-	else
-		m_ammoName = 0;
 
 	iAmmoElapsed		= pSettings->r_s32		(section,"ammo_elapsed"		);
 	iMagazineSize		= pSettings->r_s32		(section,"ammo_mag_size"	);

--- a/ogsr_engine/xrGame/Weapon.cpp
+++ b/ogsr_engine/xrGame/Weapon.cpp
@@ -1034,22 +1034,24 @@ bool CWeapon::Action(s32 cmd, u32 flags)
 	return false;
 }
 
-void GetZoomData(const float scope_factor, float& delta, float& min_zoom_factor)
+void CWeapon::GetZoomData(const float scope_factor, float& delta, float& min_zoom_factor)
 {
-	float def_fov = Core.Features.test(xrCore::Feature::ogse_wpn_zoom_system) ? 1.f : g_fov;
 	float min_zoom_k = 0.3f;
-	float zoom_step_count = 3.0f;
+	float zoom_step_count = 4.0f;
+
+	float def_fov = Core.Features.test(xrCore::Feature::ogse_wpn_zoom_system) ? 1.f : g_fov;
 	float delta_factor_total = def_fov-scope_factor;
 	VERIFY(delta_factor_total>0);
 	min_zoom_factor = def_fov-delta_factor_total*min_zoom_k;
 	delta = (delta_factor_total*(1-min_zoom_k) )/zoom_step_count;
-
 }
 
 void CWeapon::ZoomInc()
 {
 	float delta, min_zoom_factor;
 	GetZoomData(m_fScopeZoomFactor, delta, min_zoom_factor);
+
+	float currentZoomFactor = m_fZoomFactor;
 
 	if (Core.Features.test(xrCore::Feature::ogse_wpn_zoom_system)) {
 		m_fZoomFactor += delta;
@@ -1058,6 +1060,11 @@ void CWeapon::ZoomInc()
 	else {
 		m_fZoomFactor -= delta;
 		clamp(m_fZoomFactor, m_fScopeZoomFactor, min_zoom_factor);
+	}
+
+	if (!fsimilar(currentZoomFactor, m_fZoomFactor))
+	{
+		OnZoomChanged();
 	}
 }
 
@@ -1066,6 +1073,8 @@ void CWeapon::ZoomDec()
 	float delta, min_zoom_factor;
 	GetZoomData(m_fScopeZoomFactor, delta, min_zoom_factor);
 
+	float currentZoomFactor = m_fZoomFactor;
+
 	if (Core.Features.test(xrCore::Feature::ogse_wpn_zoom_system)) {
 		m_fZoomFactor -= delta;
 		clamp(m_fZoomFactor, min_zoom_factor, m_fScopeZoomFactor);
@@ -1073,6 +1082,11 @@ void CWeapon::ZoomDec()
 	else {
 		m_fZoomFactor += delta;
 		clamp(m_fZoomFactor, m_fScopeZoomFactor, min_zoom_factor);
+	}
+
+	if (!fsimilar(currentZoomFactor, m_fZoomFactor))
+	{
+		OnZoomChanged();
 	}
 }
 

--- a/ogsr_engine/xrGame/Weapon.cpp
+++ b/ogsr_engine/xrGame/Weapon.cpp
@@ -1934,8 +1934,9 @@ void CWeapon::UpdateSecondVP()
 	auto wpn_w_gl = smart_cast<CWeaponMagazinedWGrenade*>(this);
 	bool bCond_4 = ( !wpn_w_gl || !wpn_w_gl->m_bGrenadeMode );     // Мы не должны быть в режиме подствольника
 	bool bCond_5 = !is_second_zoom_offset_enabled; // Мы не должны быть в режиме второго прицеливания.
+	bool bCond_6 = IsScopeAttached(); // есть прицел на оружии
 
-	Device.m_SecondViewport.SetSVPActive(bCond_1 && bCond_2 && bCond_3 && bCond_4 && bCond_5);
+	Device.m_SecondViewport.SetSVPActive(bCond_1 && bCond_2 && bCond_3 && bCond_4 && bCond_5 && bCond_6);
 }
 
 // Чувствительность мышкии с оружием в руках во время прицеливания

--- a/ogsr_engine/xrGame/Weapon.h
+++ b/ogsr_engine/xrGame/Weapon.h
@@ -475,7 +475,6 @@ public:
 
 	CWeaponAmmo*			m_pAmmo;
 	u32						m_ammoType;
-	shared_str				m_ammoName;
 	BOOL					m_bHasTracers;
 	u8						m_u8TracerColorID;
 	u32						m_set_next_ammoType_on_reload;

--- a/ogsr_engine/xrGame/Weapon.h
+++ b/ogsr_engine/xrGame/Weapon.h
@@ -1,10 +1,9 @@
 // Weapon.h: interface for the CWeapon class.
 #pragma once
 
+#include "WeaponAmmo.h"
 #include "PhysicsShell.h"
-#include "weaponammo.h"
 #include "PHShellCreator.h"
-
 #include "ShootingObject.h"
 #include "hud_item_object.h"
 #include "Actor_Flags.h"
@@ -112,7 +111,7 @@ public:
 public:
 	virtual bool			Action(s32 cmd, u32 flags);
 
-//////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////
 //  Weapon state
 //////////////////////////////////////////////////////////////////////////
 public:
@@ -260,6 +259,7 @@ protected:
 public:
 
 	IC bool					IsZoomEnabled		()	const	{return m_bZoomEnabled;}
+	void					GetZoomData			(float scope_factor, float& delta, float& min_zoom_factor);
 	virtual	void			ZoomInc				();
 	virtual	void			ZoomDec				();
 	virtual void			OnZoomIn			();
@@ -267,6 +267,8 @@ public:
 			bool			IsZoomed			()	const	{return m_bZoomMode;};
 	CUIStaticItem*			ZoomTexture			();	
 			bool			ZoomHideCrosshair	()			{return m_bHideCrosshairInZoom || ZoomTexture();}
+
+	virtual void			OnZoomChanged		() {}
 
 	IC float				GetZoomFactor		() const		{	return m_fZoomFactor;	}
 	virtual	float			CurrentZoomFactor	();

--- a/ogsr_engine/xrGame/WeaponMagazined.cpp
+++ b/ogsr_engine/xrGame/WeaponMagazined.cpp
@@ -316,7 +316,6 @@ void CWeaponMagazined::ReloadMagazine()
 	//только разных типов патронов
 //	static bool l_lockType = false;
 	if (!m_bLockType) {
-		m_ammoName	= NULL;
 		m_pAmmo		= NULL;
 	}
 	
@@ -387,7 +386,6 @@ void CWeaponMagazined::ReloadMagazine()
 		l_cartridge.m_LocalAmmoType = u8(m_ammoType);
 		m_magazine.push_back(l_cartridge);
 	}
-	m_ammoName = (m_pAmmo) ? m_pAmmo->m_nameShort : NULL;
 
 	VERIFY((u32)iAmmoElapsed == m_magazine.size());
 

--- a/ogsr_engine/xrGame/WeaponMagazined.cpp
+++ b/ogsr_engine/xrGame/WeaponMagazined.cpp
@@ -1008,10 +1008,17 @@ void CWeaponMagazined::InitAddons()
 
 	if (m_bScopeDynamicZoom)
 	{
-		float delta, min_zoom_factor;
-		GetZoomData(m_fScopeZoomFactor, delta, min_zoom_factor);
+		if (Core.Features.test(xrCore::Feature::ogse_wpn_zoom_system)) 
+		{
+			float delta, min_zoom_factor;
+			GetZoomData(m_fScopeZoomFactor, delta, min_zoom_factor);
 
-		m_fRTZoomFactor = min_zoom_factor; // set minimal zoom by default
+			m_fRTZoomFactor = min_zoom_factor; // set minimal zoom by default for ogse mode
+		}
+		else
+		{
+			m_fRTZoomFactor = m_fScopeZoomFactor;
+		}
 	}
 
 	if(IsSilencerAttached() && SilencerAttachable())

--- a/ogsr_engine/xrGame/WeaponMagazined.cpp
+++ b/ogsr_engine/xrGame/WeaponMagazined.cpp
@@ -52,6 +52,7 @@ CWeaponMagazined::~CWeaponMagazined()
 	HUD_SOUND::DestroySound(sndEmptyClick);
 	HUD_SOUND::DestroySound(sndReload);
 	HUD_SOUND::DestroySound(sndFireModes);
+	HUD_SOUND::DestroySound(sndZoomChange);
 	if (m_binoc_vision)
 		xr_delete(m_binoc_vision);
 }
@@ -65,6 +66,7 @@ void CWeaponMagazined::StopHUDSounds		()
 	HUD_SOUND::StopSound(sndEmptyClick);
 	HUD_SOUND::StopSound(sndReload);
 	HUD_SOUND::StopSound(sndFireModes);
+	HUD_SOUND::StopSound(sndZoomChange);
 
 	HUD_SOUND::StopSound(sndShot);
 //.	if(sndShot.enable && sndShot.snd.feedback)
@@ -101,6 +103,8 @@ void CWeaponMagazined::Load	(LPCSTR section)
 	HUD_SOUND::LoadSound(section,"snd_reload"	, sndReload		, m_eSoundReload		);
 	if ( pSettings->line_exist( section, "snd_fire_modes" ) )
 		HUD_SOUND::LoadSound( section, "snd_fire_modes", sndFireModes, m_eSoundEmptyClick );
+	if ( pSettings->line_exist( section, "snd_zoom_change" ) )
+		HUD_SOUND::LoadSound( section, "snd_zoom_change", sndZoomChange, m_eSoundEmptyClick );
 	
 	m_pSndShotCurrent = &sndShot;
 		
@@ -520,6 +524,7 @@ void CWeaponMagazined::UpdateSounds	()
 	if (sndReload.playing		()) sndReload.set_position		(get_LastFP());
 	if (sndEmptyClick.playing	())	sndEmptyClick.set_position	(get_LastFP());
 	if (sndFireModes.playing	())	sndFireModes.set_position	(get_LastFP());
+	if (sndZoomChange.playing	())	sndZoomChange.set_position	(get_LastFP());
 }
 
 void CWeaponMagazined::state_Fire	(float dt)
@@ -1004,9 +1009,12 @@ void CWeaponMagazined::InitAddons()
 	}
 
 	if (m_bScopeDynamicZoom)
-    {
-		m_fRTZoomFactor = m_fScopeZoomFactor;
-    }
+	{
+		float delta, min_zoom_factor;
+		GetZoomData(m_fScopeZoomFactor, delta, min_zoom_factor);
+
+		m_fRTZoomFactor = min_zoom_factor; // set minimal zoom by default
+	}
 
 	if(IsSilencerAttached() && SilencerAttachable())
 	{		
@@ -1178,6 +1186,11 @@ void CWeaponMagazined::OnZoomOut		()
 		}
 	}
 
+}
+
+void CWeaponMagazined::OnZoomChanged()
+{
+	PlaySound(sndZoomChange, get_LastFP());
 }
 
 //переключение режимов стрельбы одиночными и очередями

--- a/ogsr_engine/xrGame/WeaponMagazined.h
+++ b/ogsr_engine/xrGame/WeaponMagazined.h
@@ -27,6 +27,7 @@ protected:
 	HUD_SOUND		sndEmptyClick;
 	HUD_SOUND		sndReload;
 	HUD_SOUND		sndFireModes;
+	HUD_SOUND		sndZoomChange;
 	//звук текущего выстрела
 	HUD_SOUND*		m_pSndShotCurrent;
 
@@ -172,6 +173,7 @@ protected:
 public:
 	virtual void	OnZoomIn			();
 	virtual void	OnZoomOut			();
+	virtual void	OnZoomChanged		();
 	virtual	void	OnNextFireMode		();
 	virtual	void	OnPrevFireMode		();
 	virtual bool	HasFireModes		() { return m_bHasDifferentFireModes; };

--- a/ogsr_engine/xrGame/WeaponMagazinedWGrenade.cpp
+++ b/ogsr_engine/xrGame/WeaponMagazinedWGrenade.cpp
@@ -590,8 +590,6 @@ bool CWeaponMagazinedWGrenade::Detach(const char* item_section_name, bool b_spaw
 	   0 != (m_flagsAddOnState&CSE_ALifeItemWeapon::eWeaponAddonGrenadeLauncher) &&
 	   !xr_strcmp(*m_sGrenadeLauncherName, item_section_name))
 	{
-		m_flagsAddOnState &= ~CSE_ALifeItemWeapon::eWeaponAddonGrenadeLauncher;
-
 		// https://github.com/revolucas/CoC-Xray/pull/5/commits/9ca73da34a58ceb48713b1c67608198c6af26db2
 		// Now we need to unload GL's magazine
 		if (!m_bGrenadeMode)
@@ -600,6 +598,8 @@ bool CWeaponMagazinedWGrenade::Detach(const char* item_section_name, bool b_spaw
 		}
 		UnloadMagazine();
 		PerformSwitchGL();
+
+		m_flagsAddOnState &= ~CSE_ALifeItemWeapon::eWeaponAddonGrenadeLauncher;
 
 		UpdateAddonsVisibility();
 		return CInventoryItemObject::Detach(item_section_name, b_spawn_item);

--- a/ogsr_engine/xrGame/WeaponMagazinedWGrenade.h
+++ b/ogsr_engine/xrGame/WeaponMagazinedWGrenade.h
@@ -106,7 +106,6 @@ public:
 	shared_str				m_ammoSect2;
 	xr_vector<shared_str>	m_ammoTypes2;
 	u32						m_ammoType2;
-	shared_str				m_ammoName2;
 	int						iMagazineSize2;
 	xr_vector<CCartridge>	m_magazine2;
 	bool					m_bGrenadeMode;

--- a/ogsr_engine/xrGame/WeaponShotgun.cpp
+++ b/ogsr_engine/xrGame/WeaponShotgun.cpp
@@ -455,7 +455,6 @@ u8 CWeaponShotgun::AddCartridge		(u8 cnt)
 		m_magazine.push_back(l_cartridge);
 //		m_fCurrentCartirdgeDisp = l_cartridge.m_kDisp;
 	}
-	m_ammoName = (m_pAmmo) ? m_pAmmo->m_nameShort : NULL;
 
 	VERIFY((u32)iAmmoElapsed == m_magazine.size());
 

--- a/ogsr_engine/xrGame/ui/UICarBodyWnd.cpp
+++ b/ogsr_engine/xrGame/ui/UICarBodyWnd.cpp
@@ -312,9 +312,12 @@ void CUICarBodyWnd::SendMessage(CUIWindow *pWnd, s16 msg, void *pData)
 						WpnMagaz->UnloadMagazine();
 						if (auto WpnMagazWgl = smart_cast<CWeaponMagazinedWGrenade*>(WpnMagaz))
 						{
-							WpnMagazWgl->PerformSwitchGL();
-							WpnMagazWgl->UnloadMagazine();
-							WpnMagazWgl->PerformSwitchGL();
+							if (WpnMagazWgl->IsGrenadeLauncherAttached())
+							{
+								WpnMagazWgl->PerformSwitchGL();
+								WpnMagazWgl->UnloadMagazine();
+								WpnMagazWgl->PerformSwitchGL();
+							}
 						}
 					};
 

--- a/ogsr_engine/xrGame/ui/UIInventoryWnd3.cpp
+++ b/ogsr_engine/xrGame/ui/UIInventoryWnd3.cpp
@@ -276,9 +276,12 @@ void CUIInventoryWnd::ProcessPropertiesBoxClicked	()
 					WpnMagaz->UnloadMagazine();
 					if (auto WpnMagazWgl = smart_cast<CWeaponMagazinedWGrenade*>(WpnMagaz))
 					{
-						WpnMagazWgl->PerformSwitchGL();
-						WpnMagazWgl->UnloadMagazine();
-						WpnMagazWgl->PerformSwitchGL();
+						if (WpnMagazWgl->IsGrenadeLauncherAttached())
+						{
+							WpnMagazWgl->PerformSwitchGL();
+							WpnMagazWgl->UnloadMagazine();
+							WpnMagazWgl->PerformSwitchGL();
+						}
 					}
 				};
 


### PR DESCRIPTION
1. Weapons dynamic zoom changes:
* Added zoom change sound via **snd_zoom_change** in weapon section
* Weapon will use minimal possible zoom level in ogse zoom mode by default.
* Dynamic Zoom steps count set to 4
2. Added check for IsScopeAttached in UpdateSecondVP to fix lags even for weapons without scope
3. Added logic to apply same rules to max_weight calculation for jump and walk power loss
4. Weapons with GL:
* Switch to GL mode when unload magazine only if GL is present
* Update addons flags only after switch GL and unload magazine when detaching GL.
* Fixed spawn of CWeaponMagazinedWGrenade in GL mode - it will update zoom offset and call lua callback
5. HUD:
* Added icon for bolt when it active item
* Added icon and text info for artefact when it active item

Minor changes:
* Removed unused m_ammoName|m_ammoName2 properties in weapon classes