### PR TITLE
Добавил отключение 3д прицелов через консоль + правки по оружейке

### DIFF
--- a/ogsr_engine/COMMON_AI/xrServer_Objects_ALife_Items.h
+++ b/ogsr_engine/COMMON_AI/xrServer_Objects_ALife_Items.h
@@ -138,7 +138,7 @@ SERVER_ENTITY_DECLARE_BEGIN(CSE_ALifeItemWeapon,CSE_ALifeItem)
 		eWeaponAddonMagazine = 0x10,
 		eWeaponAddonScopeMount = 0x20,
 
-		eVisUpdatesActivated = 0x40,
+		//eVisUpdatesActivated = 0x40,
 		eForcedNotexScope = 0x80
 	};
 

--- a/ogsr_engine/xrGame/Actor_Flags.h
+++ b/ogsr_engine/xrGame/Actor_Flags.h
@@ -11,6 +11,7 @@ enum{
 		AF_MUSIC_TRACKS		=(1<<7),
 		AF_DOF_SCOPE		=(1<<8),
 		AF_AMMO_ON_BELT		=(1<<9),
+		AF_3D_SCOPES		=(1<<10),
 };
 
 enum {

--- a/ogsr_engine/xrGame/MainMenu.cpp
+++ b/ogsr_engine/xrGame/MainMenu.cpp
@@ -33,9 +33,12 @@ CMainMenu::CMainMenu()
 	m_startDialog = NULL;
 	m_screenshotFrame = u32(-1);
 	g_pGamePersistent->m_pMainMenu = this;
-	if (Device.b_is_Ready)			OnDeviceCreate();
+	if (Device.b_is_Ready)			
+		OnDeviceCreate();
+
 	ReadTextureInfo();
 	CUIXmlInit::InitColorDefs();
+
 	g_btnHint = NULL;
 	m_deactivated_frame = 0;
 
@@ -86,6 +89,7 @@ void CMainMenu::Activate(bool bActivate)
 {
 	if (!!m_Flags.test(flActive) == bActivate)		return;
 	if (m_Flags.test(flGameSaveScreenshot))		return;
+
 	if ((m_screenshotFrame == Device.dwFrame) ||
 		(m_screenshotFrame == Device.dwFrame - 1) ||
 		(m_screenshotFrame == Device.dwFrame + 1))	return;
@@ -173,7 +177,8 @@ void CMainMenu::Activate(bool bActivate)
 		if (m_Flags.test(flNeedVidRestart))
 		{
 			m_Flags.set(flNeedVidRestart, FALSE);
-			Console->Execute("vid_restart");
+			//Console->Execute("vid_restart");
+			Device.PreCache(20);
 		}
 	}
 }

--- a/ogsr_engine/xrGame/Weapon.h
+++ b/ogsr_engine/xrGame/Weapon.h
@@ -524,6 +524,8 @@ public:
 	void UpdateSecondVP(); //
 	float GetZRotatingFactor() const { return m_fZoomRotationFactor; }    //--#SM+#--
 	float GetSecondVP_FovFactor() const { return m_fSecondVP_FovFactor; } //--#SM+#--
+	bool SecondVPEnabled();
+
 	void SwitchScope();
 };
 

--- a/ogsr_engine/xrGame/WeaponMagazined.cpp
+++ b/ogsr_engine/xrGame/WeaponMagazined.cpp
@@ -957,12 +957,15 @@ void CWeaponMagazined::InitAddons()
 			m_fScopeZoomFactor = pSettings->r_float	(*m_sScopeName, "scope_zoom_factor");
 			m_bScopeDynamicZoom = !!READ_IF_EXISTS(pSettings, r_bool, *m_sScopeName, "scope_dynamic_zoom", false);
 
-			shared_str scope_tex_name;
-			scope_tex_name = pSettings->r_string(*m_sScopeName, "scope_texture");
+			shared_str scope_tex_name = READ_IF_EXISTS(pSettings, r_string, *m_sScopeName, "scope_texture", "");
 
 			if(m_UIScope) xr_delete(m_UIScope);
-			m_UIScope = xr_new<CUIStaticItem>();
-			m_UIScope->Init(*scope_tex_name, "hud\\scope", 0, 0, alNone);
+
+			if (scope_tex_name.size() > 0)
+			{
+				m_UIScope = xr_new<CUIStaticItem>();
+				m_UIScope->Init(*scope_tex_name, "hud\\scope", 0, 0, alNone);
+			}
 
 			m_fSecondVP_FovFactor = READ_IF_EXISTS(pSettings, r_float, *m_sScopeName, "scope_lense_fov_factor", 0.0f);
 			m_fScopeInertionFactor = READ_IF_EXISTS(pSettings, r_float, *m_sScopeName, "scope_inertion_factor", m_fControlInertionFactor);
@@ -972,12 +975,15 @@ void CWeaponMagazined::InitAddons()
 			m_fScopeZoomFactor = pSettings->r_float(cNameSect(), "scope_zoom_factor");
 			m_bScopeDynamicZoom = smart_cast<CWeaponBinoculars*>(this) != nullptr || !!READ_IF_EXISTS(pSettings, r_bool, cNameSect(), "scope_dynamic_zoom", false);
 
-			shared_str scope_tex_name;
-			scope_tex_name = pSettings->r_string(cNameSect(), "scope_texture");
+			shared_str scope_tex_name = READ_IF_EXISTS(pSettings, r_string, cNameSect(), "scope_texture", "");
 
 			if(m_UIScope) xr_delete(m_UIScope);
-			m_UIScope = xr_new<CUIStaticItem>();
-			m_UIScope->Init(*scope_tex_name, "hud\\scope", 0, 0, alNone);
+
+			if (scope_tex_name.size() > 0)
+			{
+				m_UIScope = xr_new<CUIStaticItem>();
+				m_UIScope->Init(*scope_tex_name, "hud\\scope", 0, 0, alNone);
+			}
 
 			m_fSecondVP_FovFactor = READ_IF_EXISTS(pSettings, r_float, cNameSect(), "scope_lense_fov_factor", 0.0f);
 			m_fScopeInertionFactor = READ_IF_EXISTS(pSettings, r_float, cNameSect(), "scope_inertion_factor", m_fControlInertionFactor);

--- a/ogsr_engine/xrGame/WeaponMagazinedWGrenade.cpp
+++ b/ogsr_engine/xrGame/WeaponMagazinedWGrenade.cpp
@@ -292,13 +292,16 @@ bool CWeaponMagazinedWGrenade::Action(s32 cmd, u32 flags)
 	
 	switch(cmd) 
 	{
-	case kWPN_ZOOM: 
+	// case kWPN_ZOOM:  ??? 
 	case kWPN_FUNC: 
-			{
-                if(flags&CMD_START) 
-					SwitchState(eSwitch);
-				return true;
-			}
+	{
+		if (!IsZoomed())
+		{
+			if (flags&CMD_START)
+				SwitchState(eSwitch);
+			return true;
+		}
+	}
 	}
 	return false;
 }

--- a/ogsr_engine/xrGame/console_commands.cpp
+++ b/ogsr_engine/xrGame/console_commands.cpp
@@ -1236,7 +1236,8 @@ void CCC_RegisterCommands()
 	CMD3(CCC_Mask,			"g_god",				&psActorFlags,	AF_GODMODE	);
 	CMD3(CCC_Mask,			"g_unlimitedammo",		&psActorFlags,	AF_UNLIMITEDAMMO);
 	CMD3(CCC_Mask,			"g_ammunition_on_belt",	&psActorFlags,	AF_AMMO_ON_BELT);
-	CMD1(CCC_TimeFactor,	"time_factor");		
+	CMD3(CCC_Mask,			"g_3d_scopes",			&psActorFlags,	AF_3D_SCOPES);
+	CMD1(CCC_TimeFactor,	"time_factor")	
 //#endif // MASTER_GOLD
 
 	CMD3(CCC_Mask,		"g_autopickup",			&psActorFlags,	AF_AUTOPICKUP);


### PR DESCRIPTION
- Disable second vid_restart when close main menu - vid_restart already begin applied in option manager UIOptionsManager already
- Added g_3d_scopes console command: allow to enable or disable lense scopes
- Added logic to hide texture scope and suppress scope_zoom_factor if g_3d_scopes is on

- Параметр scope_texture теперь не обязательный для оружия с прицелом - если не указан не будет текстурного прицела. Сделано что бы упростить создание коллиматоров или других прицелов где не нужна текстура
- Запретил переключения режима ПГ во время прицеливания - там багов больше чем пользы было.