### PR TITLE
Правки

### DIFF
--- a/ogsr_engine/xrGame/Weapon.cpp
+++ b/ogsr_engine/xrGame/Weapon.cpp
@@ -87,6 +87,8 @@ CWeapon::CWeapon(LPCSTR name)
 	m_ef_weapon_type		= u32(-1);
 	m_UIScope				= NULL;
 	m_set_next_ammoType_on_reload = u32(-1);
+
+	m_activation_speed_is_overriden = false;
 }
 
 CWeapon::~CWeapon		()
@@ -1489,7 +1491,7 @@ void CWeapon::OnZoomIn()
 	else
 		m_fZoomFactor = CurrentZoomFactor();
 
-	if (UseScopeTexture() || !m_bZoomInertionAllow)
+	if (!m_bZoomInertionAllow)
 	{
 		StopHudInertion();
 	}
@@ -1514,10 +1516,7 @@ void CWeapon::OnZoomOut()
 		}
 	}
 
-	if (UseScopeTexture() || !m_bZoomInertionAllow)
-	{
-		StartHudInertion();
-	}
+	StartHudInertion();
 }
 
 bool CWeapon::UseScopeTexture() {
@@ -2001,7 +2000,7 @@ bool CWeapon::SecondVPEnabled() const
 // Чувствительность мышкии с оружием в руках во время прицеливания
 float CWeapon::GetControlInertionFactor() const
 {
-	if (IsZoomed() && SecondVPEnabled())
+	if (IsZoomed() && SecondVPEnabled() && !IsRotatingToZoom())
 		return m_fScopeInertionFactor;
 
 	float fInertionFactor = inherited::GetControlInertionFactor();

--- a/ogsr_engine/xrGame/script_game_object.h
+++ b/ogsr_engine/xrGame/script_game_object.h
@@ -653,6 +653,7 @@ public:
 			float				GetMaxWeight() const;
 			float				GetMaxWalkWeight() const;
 			float				GetInventoryWeight() const;
+			u32					CalcItemPrice(CScriptGameObject *item, bool b_buying) const;
 
 			float GetShapeRadius() const;
 

--- a/ogsr_engine/xrGame/script_game_object3.cpp
+++ b/ogsr_engine/xrGame/script_game_object3.cpp
@@ -1000,6 +1000,28 @@ float CScriptGameObject::GetInventoryWeight() const
 	return e->GetCarryWeight();
 }
 
+#include "trade.h"
+
+u32 CScriptGameObject::CalcItemPrice(CScriptGameObject *item, bool b_buying) const
+{
+	auto inventory_owner = smart_cast<CInventoryOwner*>(&object());
+	if (!inventory_owner)
+	{
+		Msg("!!CInventoryOwner : cannot access class member CalcItemPrice!");
+		return 0;
+	}
+	auto inventory_item = smart_cast<CInventoryItem*>(&item->object());
+	if (!inventory_item) {
+		ai().script_engine().script_log(ScriptStorage::eLuaMessageTypeError, "CScriptGameObject::CalcItemPrice non-CInventoryItem object !!!");
+		return 0;
+	}
+
+	inventory_owner->GetTrade()->SetPartner(Actor());
+	const u32 item_price = inventory_owner->GetTrade()->GetItemPrice(inventory_item, b_buying);
+	inventory_owner->GetTrade()->RemovePartner();
+	return item_price;
+}
+
 float CScriptGameObject::GetShapeRadius() const
 {
 	if (!g_pGameLevel)

--- a/ogsr_engine/xrGame/script_game_object_script3.cpp
+++ b/ogsr_engine/xrGame/script_game_object_script3.cpp
@@ -383,6 +383,7 @@ class_<CScriptGameObject> script_register_game_object2(class_<CScriptGameObject>
 		.def("get_max_weight", &CScriptGameObject::GetMaxWeight)
 		.def("get_max_walk_weight", &CScriptGameObject::GetMaxWalkWeight)
 		.def("get_inventory_weight", &CScriptGameObject::GetInventoryWeight)
+		.def("calculate_item_price", &CScriptGameObject::CalcItemPrice)
 
 		.def("get_shape_radius", &CScriptGameObject::GetShapeRadius)
 

--- a/ogsr_engine/xrGame/trade.h
+++ b/ogsr_engine/xrGame/trade.h
@@ -40,8 +40,6 @@ public:
 							CTrade					(CInventoryOwner	*p_io);
 							~CTrade					();
 
-	
-
 	bool					CanTrade				();
 	
 	void					StartTrade				(CInventoryOwner* pInvOwner);
@@ -60,9 +58,10 @@ public:
 	u32						GetItemPrice			(CInventoryItem* pItem, bool b_buying);
 
 	void					UpdateTrade				();
+
+	bool					SetPartner(CEntity *p);
+	void					RemovePartner();
 private:
-	bool					SetPartner				(CEntity *p);
-	void					RemovePartner			();
 
 	CInventory&				GetTradeInv				(SInventoryOwner owner);
 };


### PR DESCRIPTION
1. Добавил инициализацию для m_activation_speed_is_overriden - исправил урон ГГ когда тот бросал или выкладывал оружие
2. Немного поменял включение\отключение инерции при прицеливании - пусть включается всегда и отключается тоже если нету allow_zoom_inertion
3. scope_inertion_factor будем применять только когда завершили поворот для прицеливания
4. Добавил метод **calculate_item_price** для клиентского объекта CInventoryOwner.
Позволяет получить у торговца реальную цену покупки или продажи айтема для актора.
Сигнатура:
npc:calculate_item_price(item, b_buying) где
item - lua объект предмета
b_buying - флаг покупаем или продаем