### PR TITLE
Правки по оружию

### DIFF
--- a/ogsr_engine/xrGame/Actor.cpp
+++ b/ogsr_engine/xrGame/Actor.cpp
@@ -1367,7 +1367,7 @@ void CActor::ForceTransform(const Fmatrix& m)
 	character_physics_support()->movement()->SetVelocity		(0,0,0);
 }
 
-ENGINE_API extern float		psHUD_FOV;
+//ENGINE_API extern float		psHUD_FOV;
 float CActor::Radius()const
 { 
 	float R		= inherited::Radius();

--- a/ogsr_engine/xrGame/Actor.cpp
+++ b/ogsr_engine/xrGame/Actor.cpp
@@ -863,9 +863,8 @@ void CActor::UpdateCL	()
 			
 			// Обновляем информацию об оружии в шейдерах
 			g_pGamePersistent->m_pGShaderConstants.hud_params.x = pWeapon->GetZRotatingFactor(); //--#SM+#--
-			g_pGamePersistent->m_pGShaderConstants.hud_params.y = pWeapon->GetSecondVP_FovFactor(); //--#SM+#--
+			g_pGamePersistent->m_pGShaderConstants.hud_params.y = pWeapon->GetSecondVPFov(); //--#SM+#--
 		}
-
 	}
 	else
 	{

--- a/ogsr_engine/xrGame/ActorCameras.cpp
+++ b/ogsr_engine/xrGame/ActorCameras.cpp
@@ -21,6 +21,10 @@
 #include "EffectorShot.h"
 #include "phcollidevalidator.h"
 #include "PHShell.h"
+
+ENGINE_API extern float psHUD_FOV; //--#SM+#--
+ENGINE_API extern float psHUD_FOV_def; //--#SM+#--
+
 void CActor::cam_Set	(EActorCameras style)
 {
 	CCameraBase* old_cam = cam_Active();
@@ -136,7 +140,19 @@ float cam_HeightInterpolationSpeed = 8.f;
 #include "debug_renderer.h"
 void CActor::cam_Update(float dt, float fFOV)
 {
-	if(m_holder)		return;
+	if(m_holder)
+		return;
+
+	// HUD FOV Update --#SM+#--
+	if (this == Level().CurrentControlEntity())
+	{
+		CWeapon* pWeapon = smart_cast<CWeapon*>(this->inventory().ActiveItem());
+		if (eacFirstEye == cam_active && pWeapon)
+			psHUD_FOV = pWeapon->GetHudFov();
+		else
+			psHUD_FOV = psHUD_FOV_def;
+	}
+	//--#SM+#--
 
 	if(mstate_real & mcClimb&&cam_active!=eacFreeLook)
 		camUpdateLadder(dt);

--- a/ogsr_engine/xrGame/Weapon.cpp
+++ b/ogsr_engine/xrGame/Weapon.cpp
@@ -372,6 +372,9 @@ void CWeapon::Load		(LPCSTR section)
 	m_eGrenadeLauncherStatus = (ALife::EWeaponAddonStatus)pSettings->r_s32(section,"grenade_launcher_status");
 
 	m_bZoomEnabled = !!pSettings->r_bool(section,"zoom_enabled");
+	m_bUseScopeZoom = !!READ_IF_EXISTS(pSettings, r_bool, section, "use_scope_zoom", false);
+	m_bUseScopeGrenadeZoom = !!READ_IF_EXISTS(pSettings, r_bool, section, "use_scope_grenade_zoom", false);
+
 	m_fZoomRotateTime = ROTATION_TIME;
 	m_bScopeDynamicZoom = false;
 	m_fScopeZoomFactor = 0;
@@ -511,13 +514,11 @@ void CWeapon::LoadZoomOffset(LPCSTR section, LPCSTR prefix)
 		is_second_zoom_offset_enabled = false;
 		//Msg("~~Second scope disabled!");
 	}
+
 	//Зум фактор обновлять здесь необходимо. second_soom_factor поддерживается.
-	auto wpn_w_gl = smart_cast<CWeaponMagazinedWGrenade*>(this);
-	if (wpn_w_gl)
-		m_fZoomFactor = wpn_w_gl->CurrentZoomFactor();
-	else
-		m_fZoomFactor = this->CurrentZoomFactor();
+	m_fZoomFactor = this->CurrentZoomFactor();
 	//
+
 	if(pSettings->line_exist(hud_sect, "zoom_rotate_time"))
 		m_fZoomRotateTime = pSettings->r_float(hud_sect,"zoom_rotate_time");
 
@@ -526,21 +527,31 @@ void CWeapon::LoadZoomOffset(LPCSTR section, LPCSTR prefix)
 
 void CWeapon::UpdateZoomOffset() //Собрал все манипуляции с зум оффсетом сюда, чтоб были в одном месте.
 {
-	if (m_bZoomEnabled && m_pHUD) {
-		auto wpn_w_gl = smart_cast<CWeaponMagazinedWGrenade*>(this);
-		if (wpn_w_gl) {
-			if (wpn_w_gl->m_bGrenadeMode)
-				LoadZoomOffset(*hud_sect, "grenade_");
+	if (m_bZoomEnabled && m_pHUD)
+	{
+		const bool has_gl = GrenadeLauncherAttachable() && IsGrenadeLauncherAttached();
+		const bool has_scope = ScopeAttachable() && IsScopeAttached();
+
+		if (IsGrenadeMode())
+		{
+			if (m_bUseScopeGrenadeZoom && has_scope)
+				LoadZoomOffset(*hud_sect, "scope_grenade_");
 			else
-			{
-				if ( GrenadeLauncherAttachable() && IsGrenadeLauncherAttached() )
-					LoadZoomOffset(*hud_sect, "grenade_normal_");
-				else
-					LoadZoomOffset(*hud_sect, "");
-			}
+				LoadZoomOffset(*hud_sect, "grenade_");
 		}
-		else {
-			LoadZoomOffset(*hud_sect, "");
+		else if (has_gl)
+		{
+			if (m_bUseScopeZoom && has_scope)
+				LoadZoomOffset(*hud_sect, "scope_grenade_normal_");
+			else
+				LoadZoomOffset(*hud_sect, "grenade_normal_");
+		}
+		else
+		{
+			if (m_bUseScopeZoom && has_scope)
+				LoadZoomOffset(*hud_sect, "scope_");
+			else
+				LoadZoomOffset(*hud_sect, "");
 		}
 	}
 }
@@ -1019,17 +1030,10 @@ bool CWeapon::Action(s32 cmd, u32 flags)
 			if (IsZoomEnabled() && IsZoomed() && m_bScopeDynamicZoom && IsScopeAttached() && !is_second_zoom_offset_enabled && (flags&CMD_START))
 			{
 				// если в режиме ПГ - не будем давать использовать динамический зум
-				auto wpn_w_gl = smart_cast<CWeaponMagazinedWGrenade*>(this);
-				if (wpn_w_gl && wpn_w_gl->m_bGrenadeMode)
+				if (IsGrenadeMode())
 					return false;
 
-				if (cmd == kWPN_ZOOM_INC)  
-					ZoomInc();
-				else
-					ZoomDec();
-
-				if (H_Parent() && !IsRotatingToZoom())
-					m_fRTZoomFactor = m_fZoomFactor; //store current
+				ZoomChange(cmd == kWPN_ZOOM_INC);
 
 				return true;
 			}
@@ -1059,45 +1063,45 @@ void CWeapon::GetZoomData(const float scope_factor, float& delta, float& min_zoo
 	delta = (delta_factor_total*(1-min_zoom_k) )/zoom_step_count;
 }
 
-void CWeapon::ZoomInc()
+void CWeapon::ZoomChange(bool inc)
 {
-	float delta, min_zoom_factor;
-	GetZoomData(m_fScopeZoomFactor, delta, min_zoom_factor);
+	bool wasChanged = false;
 
-	float currentZoomFactor = m_fZoomFactor;
-
-	if (Core.Features.test(xrCore::Feature::ogse_wpn_zoom_system)) {
-		m_fZoomFactor += delta;
-		clamp(m_fZoomFactor, min_zoom_factor, m_fScopeZoomFactor);
-	}
-	else {
-		m_fZoomFactor -= delta;
-		clamp(m_fZoomFactor, m_fScopeZoomFactor, min_zoom_factor);
-	}
-
-	if (!fsimilar(currentZoomFactor, m_fZoomFactor))
+	if (SecondVPEnabled())
 	{
-		OnZoomChanged();
+		float delta, min_zoom_factor;
+		GetZoomData(m_fSecondVP_FovFactor, delta, min_zoom_factor);
+
+		const float currentZoomFactor = m_fRTZoomFactor;
+
+		m_fRTZoomFactor += delta * (inc ? 1 : -1);
+		clamp(m_fRTZoomFactor, min_zoom_factor, m_fSecondVP_FovFactor);
+
+		wasChanged = !fsimilar(currentZoomFactor, m_fRTZoomFactor);
 	}
-}
+	else
+	{
+		float delta, min_zoom_factor;
+		GetZoomData(m_fScopeZoomFactor, delta, min_zoom_factor);
 
-void CWeapon::ZoomDec()
-{
-	float delta, min_zoom_factor;
-	GetZoomData(m_fScopeZoomFactor, delta, min_zoom_factor);
+		const float currentZoomFactor = m_fZoomFactor;
 
-	float currentZoomFactor = m_fZoomFactor;
+		if (Core.Features.test(xrCore::Feature::ogse_wpn_zoom_system)) {
+			m_fZoomFactor += delta * (inc ? 1 : -1);
+			clamp(m_fZoomFactor, min_zoom_factor, m_fScopeZoomFactor);
+		}
+		else {
+			m_fZoomFactor -= delta * (inc ? 1 : -1);
+			clamp(m_fZoomFactor, m_fScopeZoomFactor, min_zoom_factor);
+		}
 
-	if (Core.Features.test(xrCore::Feature::ogse_wpn_zoom_system)) {
-		m_fZoomFactor -= delta;
-		clamp(m_fZoomFactor, min_zoom_factor, m_fScopeZoomFactor);
+		wasChanged = !fsimilar(currentZoomFactor, m_fZoomFactor);
+
+		if (H_Parent() && !IsRotatingToZoom() && !SecondVPEnabled())
+			m_fRTZoomFactor = m_fZoomFactor; //store current
 	}
-	else {
-		m_fZoomFactor += delta;
-		clamp(m_fZoomFactor, m_fScopeZoomFactor, min_zoom_factor);
-	}
 
-	if (!fsimilar(currentZoomFactor, m_fZoomFactor))
+	if (wasChanged)
 	{
 		OnZoomChanged();
 	}
@@ -1482,9 +1486,7 @@ void CWeapon::OnZoomIn()
 	m_bZoomMode = true;
 
 	// если в режиме ПГ - не будем давать включать динамический зум
-	auto wpn_w_gl = smart_cast<CWeaponMagazinedWGrenade*>(this);
-
-	if ( m_bScopeDynamicZoom && (!wpn_w_gl || !wpn_w_gl->m_bGrenadeMode))
+	if ( m_bScopeDynamicZoom && !IsGrenadeMode() && !SecondVPEnabled())
 		m_fZoomFactor = m_fRTZoomFactor;
 	else
 		m_fZoomFactor = CurrentZoomFactor();
@@ -1961,14 +1963,9 @@ void CWeapon::UpdateSecondVP()
 }
 
 bool CWeapon::SecondVPEnabled() const
-{
-	const CActor* pActor = smart_cast<const CActor*>(H_Parent());
-	if (!pActor)
-		return false;
-	
+{	
 	bool bCond_2 = m_fSecondVP_FovFactor > 0.0f;     // В конфиге должен быть прописан фактор зума (scope_lense_fov_factor) больше чем 0
-	auto wpn_w_gl = smart_cast<const CWeaponMagazinedWGrenade*>(this);
-	bool bCond_4 = (!wpn_w_gl || !wpn_w_gl->m_bGrenadeMode);     // Мы не должны быть в режиме подствольника
+	bool bCond_4 = !IsGrenadeMode();     // Мы не должны быть в режиме подствольника
 	bool bCond_5 = !is_second_zoom_offset_enabled; // Мы не должны быть в режиме второго прицеливания.
 	bool bcond_6 = psActorFlags.test(AF_3D_SCOPES);
 
@@ -1983,4 +1980,20 @@ float CWeapon::GetControlInertionFactor() const
 
 	float fInertionFactor = inherited::GetControlInertionFactor();
 	return fInertionFactor;
+}
+
+float CWeapon::GetSecondVPFov() const
+{
+	float fov_factor = m_fSecondVP_FovFactor;
+	if (m_bScopeDynamicZoom)
+	{
+		fov_factor = m_fRTZoomFactor;
+	}
+	return float(atan(tan(g_fov * (0.5 * PI / 180)) / fov_factor) / (0.5 * PI / 180)); //-V595
+}
+
+bool CWeapon::IsGrenadeMode() const
+{
+	const auto wpn_w_gl = smart_cast<const CWeaponMagazinedWGrenade*>(this);
+	return wpn_w_gl && wpn_w_gl->m_bGrenadeMode;
 }

--- a/ogsr_engine/xrGame/Weapon.h
+++ b/ogsr_engine/xrGame/Weapon.h
@@ -256,13 +256,15 @@ protected:
 	bool			m_bHideCrosshairInZoom;
 	bool			m_bZoomInertionAllow;
 
+	bool m_bUseScopeZoom		= false;
+	bool m_bUseScopeGrenadeZoom		= false;
+
 	float			m_fScopeInertionFactor;
 public:
 
 	IC bool					IsZoomEnabled		()	const	{return m_bZoomEnabled;}
 	void					GetZoomData			(float scope_factor, float& delta, float& min_zoom_factor);
-	virtual	void			ZoomInc				();
-	virtual	void			ZoomDec				();
+	virtual	void			ZoomChange			(bool inc);
 	virtual void			OnZoomIn			();
 	virtual void			OnZoomOut			();
 			bool			IsZoomed			()	const	{return m_bZoomMode;};
@@ -369,6 +371,8 @@ protected:
 	virtual void			AddShotEffector		();
 	virtual void			RemoveShotEffector	();
 	virtual	void			ClearShotEffector	();
+
+	bool			IsGrenadeMode() const;
 
 public:
 	//текущая дисперсия (в радианах) оружия с учетом используемого патрона
@@ -523,8 +527,8 @@ public:
 	void UpdateZoomOffset();
 	//
 	void UpdateSecondVP(); //
-	float GetZRotatingFactor() const { return m_fZoomRotationFactor; }    //--#SM+#--
-	float GetSecondVP_FovFactor() const { return m_fSecondVP_FovFactor; } //--#SM+#--
+	float GetZRotatingFactor() const { return m_fZoomRotationFactor; } //--#SM+#--
+	float GetSecondVPFov() const; //--#SM+#--
 	bool SecondVPEnabled() const;
 
 	void SwitchScope();

--- a/ogsr_engine/xrGame/Weapon.h
+++ b/ogsr_engine/xrGame/Weapon.h
@@ -21,6 +21,12 @@ class CWeaponMagazined;
 class CParticlesObject;
 class CUIStaticItem;
 
+ENGINE_API extern float psHUD_FOV;
+ENGINE_API extern float psHUD_FOV_def;
+
+constexpr float def_min_zoom_k = 0.3f;
+constexpr float def_zoom_step_count = 4.0f;
+
 class CWeapon : public CHudItemObject,
 				public CShootingObject
 {
@@ -229,9 +235,10 @@ protected:
 //	для режима приближения и снайперского прицела
 ///////////////////////////////////////////////////
 protected:
-	// разрешение регулирования приближения. Real Wolf.
+	//разрешение регулирования приближения. Real Wolf.
 	bool			m_bScopeDynamicZoom;
-	float			m_fRTZoomFactor; //run-time zoom factor
+	//run-time zoom factor
+	float			m_fRTZoomFactor;
 	//разрешение режима приближения
 	bool			m_bZoomEnabled;
 	//текущий фактор приближения
@@ -251,13 +258,22 @@ protected:
 	//от 0 до 1, показывает насколько процентов
 	//мы перемещаем HUD  
 	float			m_fZoomRotationFactor;
-	//модификатор изменения FOV во втором вьюпорте при зуме
-	float m_fSecondVP_FovFactor; 
+	//коэффициент увеличения во втором вьюпорте при зуме
+	float			m_fSecondVPZoomFactor;
+	//прятать перекрестие в режиме прицеливания
 	bool			m_bHideCrosshairInZoom;
+	//разрешить инерцию оружия в режиме прицеливания
 	bool			m_bZoomInertionAllow;
+	//Целевой HUD FOV при зуме
+	float			m_fZoomHudFov;
+	//Целевой HUD FOV для линзы
+	float			m_fSecondVPHudFov;
 
-	bool m_bUseScopeZoom		= false;
+	bool m_bUseScopeZoom			= false;
 	bool m_bUseScopeGrenadeZoom		= false;
+
+	float m_fMinZoomK			= def_min_zoom_k;
+	float m_fZoomStepCount		= def_zoom_step_count;
 
 	float			m_fScopeInertionFactor;
 public:
@@ -530,6 +546,7 @@ public:
 	float GetZRotatingFactor() const { return m_fZoomRotationFactor; } //--#SM+#--
 	float GetSecondVPFov() const; //--#SM+#--
 	bool SecondVPEnabled() const;
+	float GetHudFov();
 
 	void SwitchScope();
 };

--- a/ogsr_engine/xrGame/WeaponMagazined.h
+++ b/ogsr_engine/xrGame/WeaponMagazined.h
@@ -115,6 +115,7 @@ public:
 	virtual bool	CanDetach(const char* item_section_name);
 
 	virtual void	InitAddons();
+	virtual void	InitZoomParams(LPCSTR section, bool useTexture);
 
 	virtual bool	Action			(s32 cmd, u32 flags);
 	virtual void	onMovementChanged	(ACTOR_DEFS::EMoveCommand cmd);

--- a/ogsr_engine/xrGame/WeaponMagazinedWGrenade.cpp
+++ b/ogsr_engine/xrGame/WeaponMagazinedWGrenade.cpp
@@ -629,8 +629,6 @@ void CWeaponMagazinedWGrenade::InitAddons()
 		{
 			CRocketLauncher::m_fLaunchSpeed = pSettings->r_float(*m_sGrenadeLauncherName,"grenade_vel");
 		}
-
-		UpdateZoomOffset();
 	}
 
 	callback(GameObject::eOnAddonInit)(2);

--- a/ogsr_engine/xrGame/console_commands.cpp
+++ b/ogsr_engine/xrGame/console_commands.cpp
@@ -49,7 +49,7 @@ extern	u64		g_qwStartGameTime;
 extern	u64		g_qwEStartGameTime;
 
 ENGINE_API
-extern	float	psHUD_FOV;
+extern	float	psHUD_FOV_def;
 extern	float	psSqueezeVelocity;
 
 extern	int		x_m_x;
@@ -1147,7 +1147,7 @@ void CCC_RegisterCommands()
 	CMD3(CCC_Mask,				"hud_crosshair_dist",	&psHUD_Flags,	HUD_CROSSHAIR_DIST);
 
 //#ifdef DEBUG
-	CMD4(CCC_Float,				"hud_fov",				&psHUD_FOV,		0.1f,	1.0f);
+	CMD4(CCC_Float,				"hud_fov",				&psHUD_FOV_def,		0.1f,	1.0f);
 	CMD4(CCC_Float,				"fov",					&g_fov,			5.0f,	140.0f);
 //#endif // DEBUG
 

--- a/ogsr_engine/xrGame/derived_client_classes.cpp
+++ b/ogsr_engine/xrGame/derived_client_classes.cpp
@@ -517,7 +517,7 @@ void CWeaponScript::script_register(lua_State *L)
 			.def("switch_scope"							,			&CWeapon::SwitchScope)
 			.def_readwrite("scope_inertion_factor"		,			&CWeapon::m_fScopeInertionFactor)
 
-			.def_readwrite("scope_lense_fov_factor",				&CWeapon::m_fSecondVP_FovFactor)
+			.def_readwrite("scope_lense_fov_factor",				&CWeapon::m_fSecondVPZoomFactor)
 			.def("second_vp_enabled",								&CWeapon::SecondVPEnabled)
 
 			.property("ammo_elapsed"					,			&CWeapon::GetAmmoElapsed, &CWeapon::SetAmmoElapsed)

--- a/ogsr_engine/xr_3da/CameraManager.h
+++ b/ogsr_engine/xr_3da/CameraManager.h
@@ -103,6 +103,7 @@ class ENGINE_API CCameraManager
 	EffectorPPVec			m_EffectorsPP;
 
 	float					fFov;
+	float					fFovSecond;
 	float					fFar;
 	float					fAspect;
 	bool					m_bAutoApply;

--- a/ogsr_engine/xr_3da/Environment_render.cpp
+++ b/ogsr_engine/xr_3da/Environment_render.cpp
@@ -82,7 +82,7 @@ const	u32 v_clouds_fvf	= D3DFVF_XYZ | D3DFVF_DIFFUSE | D3DFVF_SPECULAR;
 //-----------------------------------------------------------------------------
 // Environment render
 //-----------------------------------------------------------------------------
-extern float psHUD_FOV;
+
 BOOL bNeed_re_create_env = FALSE;
 void CEnvironment::RenderSky		()
 {

--- a/ogsr_engine/xr_3da/xr_ioc_cmd.cpp
+++ b/ogsr_engine/xr_3da/xr_ioc_cmd.cpp
@@ -392,7 +392,8 @@ public:
 };
 //-----------------------------------------------------------------------
 
-ENGINE_API float	psHUD_FOV=0.45f;
+ENGINE_API float	psHUD_FOV_def=0.45f;
+ENGINE_API float	psHUD_FOV=psHUD_FOV_def;
 
 extern int			psSkeletonUpdate;
 extern int			rsDVB_Size;


### PR DESCRIPTION
1. Переделана логика работы **scope_dynamic_zoom** для прицелов с **scope_lense_fov_factor** - теперь динамический зум будет именно в линзе.

2. Добавил поддержку текстурных прицелов для оружие с **scope_status=2** когда снят прицел. Для включения нужно добавить **force_scope_texture=true** в секцию оружия.

3. Добавлены новые параметры к настройкам zoom offset/zoom rotate для оружия с scope_status=2 что бы отдельно настраивать прицеливание с прицелом и без него:
* Прицел установлен
scope_zoom_offset
scope_zoom_rotate_x
scope_zoom_rotate_y
* Прицел установлен вместе с ПГ
scope_grenade_normal_zoom_offset
scope_grenade_normal_zoom_rotate_x
scope_grenade_normal_zoom_rotate_y
* Прицел установлен в режиме ПГ
scope_grenade_zoom_offset
scope_grenade_zoom_rotate_x
scope_grenade_zoom_rotate_y
* Все параметры не обязательные.
Для активации №1 и №2 в секцию оружия нужно добавить параметр use_scope_zoom=true
Для активации №3 в секцию оружия нужно добавить параметр use_scope_grenade_zoom=true

4. Добавлены параметры в секции оружия:
**scope_zoom_hud_fov** - худ фов во время обычного прицеливания
**scope_lense_hud_fov** - худ фов во время работы линцы.
Позволяет довольно гибко настроить приближение оружия во время прицеливания "к экрану"

5. Расширены возможности **scope_dynamic_zoom**:
Формат `scope_dynamic_zoom     = true, <steps>, <min_zoom_k`
`<steps>` - число "шагов" для регулировки зума. По умолчанию 4
`<min_zoom_k>` - коэффициент для вычисления минимального зума. По умолчанию 0,3