### PR TITLE
Правки

### DIFF
--- a/ogsr_engine/xrGame/Actor.h
+++ b/ogsr_engine/xrGame/Actor.h
@@ -449,7 +449,7 @@ public:
 	void					UpdateMotionIcon		(u32 mstate_rl);
 
 	bool					CanAccelerate			();
-	bool					CanJump					();
+	bool					CanJump					(float weight);
 	bool					CanMove					();
 	float					CameraHeight			();
 	float					CurrentHeight;

--- a/ogsr_engine/xrGame/ActorCondition.h
+++ b/ogsr_engine/xrGame/ActorCondition.h
@@ -58,6 +58,7 @@ public:
 	virtual bool		IsCantWalk					();
 	virtual bool		IsCantWalkWeight			();
 	virtual bool		IsCantSprint				();
+	virtual bool		IsCantJump					(float weight);
 
 	void		PowerHit					(float power, bool apply_outfit);
 	virtual void		UpdatePower();
@@ -120,6 +121,8 @@ protected:
 	float m_fOverweightJumpK;
 	float m_fAccelK;
 	float m_fSprintK;
+
+	bool m_bJumpRequirePower;
 
 	float	m_f_time_affected;
 	

--- a/ogsr_engine/xrGame/HUDManager.cpp
+++ b/ogsr_engine/xrGame/HUDManager.cpp
@@ -231,7 +231,7 @@ void  CHUDManager::RenderUI()
 	if (psHUD_Flags.is(HUD_CROSSHAIR|HUD_CROSSHAIR_RT|HUD_CROSSHAIR_RT2) && !bAlready)	
 		m_pHUDTarget->Render();
 
-	draw_wnds_rects		();
+	// draw_wnds_rects		(); -- вызываеться так же после RenderUI
 
 	if( Device.Paused() && bShowPauseString){
 		CGameFont* pFont	= Font().pFontGraffiti50Russian;

--- a/ogsr_engine/xrGame/Level.cpp
+++ b/ogsr_engine/xrGame/Level.cpp
@@ -40,6 +40,7 @@
 #include "../xr_3da/XR_IOConsole.h"
 #include "Debug_Renderer.h"
 #include "Actor_Flags.h"
+#include "level_changer.h"
 
 #ifdef DEBUG
 #	include "level_debug.h"
@@ -483,6 +484,10 @@ void CLevel::OnRender()
 			auto space_restrictor = smart_cast<CSpaceRestrictor*>(_O);
 			if (space_restrictor)
 				space_restrictor->OnRender();
+
+			auto level_changer = smart_cast<CLevelChanger*>(_O);
+			if (level_changer)
+				level_changer->OnRender();
 
 			auto climable = smart_cast<CClimableObject*>(_O);
 			if (climable)

--- a/ogsr_engine/xrGame/Weapon.cpp
+++ b/ogsr_engine/xrGame/Weapon.cpp
@@ -1988,10 +1988,21 @@ bool CWeapon::SecondVPEnabled() const
 // Чувствительность мышкии с оружием в руках во время прицеливания
 float CWeapon::GetControlInertionFactor() const
 {
-	if (IsZoomed() && SecondVPEnabled() && !IsRotatingToZoom())
-		return m_fScopeInertionFactor;
-
 	float fInertionFactor = inherited::GetControlInertionFactor();
+
+	if (IsZoomed() && SecondVPEnabled() && !IsRotatingToZoom())
+	{
+		if (m_bScopeDynamicZoom)
+		{
+			const float delta_factor_total = 1 - m_fSecondVPZoomFactor;
+			float min_zoom_factor = 1 + delta_factor_total * m_fMinZoomK;
+			float k = (m_fRTZoomFactor - min_zoom_factor) / (m_fSecondVPZoomFactor - min_zoom_factor);
+			return (m_fScopeInertionFactor - fInertionFactor) * k + fInertionFactor;
+		}
+		else
+			return m_fScopeInertionFactor;
+	}
+
 	return fInertionFactor;
 }
 

--- a/ogsr_engine/xrGame/Weapon.cpp
+++ b/ogsr_engine/xrGame/Weapon.cpp
@@ -87,6 +87,8 @@ CWeapon::CWeapon(LPCSTR name)
 	m_ef_weapon_type		= u32(-1);
 	m_UIScope				= NULL;
 	m_set_next_ammoType_on_reload = u32(-1);
+
+	m_nearwall_last_hud_fov = psHUD_FOV_def;
 }
 
 CWeapon::~CWeapon		()
@@ -389,7 +391,6 @@ void CWeapon::Load		(LPCSTR section)
 		m_iScopeY = pSettings->r_s32(section,"scope_y");
 	}
 
-    
 	if(m_eSilencerStatus == ALife::eAddonAttachable)
 	{
 		m_sSilencerName = pSettings->r_string(section,"silencer_name");
@@ -397,7 +398,6 @@ void CWeapon::Load		(LPCSTR section)
 		m_iSilencerY = pSettings->r_s32(section,"silencer_y");
 	}
 
-    
 	if(m_eGrenadeLauncherStatus == ALife::eAddonAttachable)
 	{
 		m_sGrenadeLauncherName = pSettings->r_string(section,"grenade_launcher_name");
@@ -462,16 +462,26 @@ void CWeapon::Load		(LPCSTR section)
 	}
 	
 	m_highlightAddons.clear();
-	if ( pSettings->line_exist( section, "highlight_addons" ) ) {
-	  LPCSTR S = pSettings->r_string( section, "highlight_addons" );
-	  if ( S && S[ 0 ] ) {
-	    string128 _addonItem;
-	    int count = _GetItemCount( S );
-	    for ( int it = 0; it < count; ++it ) {
-	      _GetItem( S, it, _addonItem );
-	      m_highlightAddons.push_back( _addonItem );
-	    }
-	  }
+	if (pSettings->line_exist(section, "highlight_addons")) {
+		LPCSTR S = pSettings->r_string(section, "highlight_addons");
+		if (S && S[0]) {
+			string128 _addonItem;
+			int count = _GetItemCount(S);
+			for (int it = 0; it < count; ++it) {
+				_GetItem(S, it, _addonItem);
+				m_highlightAddons.push_back(_addonItem);
+			}
+		}
+	}
+
+	m_nearwall_on = READ_IF_EXISTS(pSettings, r_bool, section, "nearwall_on", false);
+	if (m_nearwall_on)
+	{
+		// Параметры изменения HUD FOV когда игрок стоит вплотную к стене
+		m_nearwall_target_hud_fov = READ_IF_EXISTS(pSettings, r_float, section, "nearwall_target_hud_fov", 0.27f);
+		m_nearwall_dist_min = READ_IF_EXISTS(pSettings, r_float, section, "nearwall_dist_min", 0.5f);
+		m_nearwall_dist_max = READ_IF_EXISTS(pSettings, r_float, section, "nearwall_dist_max", 1.f);
+		m_nearwall_speed_mod = READ_IF_EXISTS(pSettings, r_float, section, "nearwall_speed_mod", 10.f);
 	}
 }
 
@@ -778,6 +788,7 @@ void CWeapon::OnH_B_Independent	(bool just_before_destroy)
 	m_fZoomRotationFactor	= 0.f;
 	UpdateXForm					();
 
+	m_nearwall_last_hud_fov = psHUD_FOV_def;
 }
 
 void CWeapon::OnH_A_Independent	()
@@ -820,6 +831,8 @@ void CWeapon::OnH_B_Chield		()
 
 	OnZoomOut					();
 	m_set_next_ammoType_on_reload	= u32(-1);
+
+	m_nearwall_last_hud_fov = psHUD_FOV_def;
 }
 
 static float state_time = 0;				// таймер нахождения оружия в текущем состоянии
@@ -2001,22 +2014,45 @@ bool CWeapon::IsGrenadeMode() const
 // Получить HUD FOV от текущего оружия игрока
 float CWeapon::GetHudFov()
 {
+	// Рассчитываем HUD FOV от бедра (с учётом упирания в стены)
+	if (m_nearwall_on && ParentIsActor() && Level().CurrentViewEntity() == H_Parent())
+	{
+		// Получаем расстояние от камеры до точки в прицеле
+		collide::rq_result& RQ = HUD().GetCurrentRayQuery();
+		float dist = RQ.range;
+
+		// Интерполируем расстояние в диапазон от 0 (min) до 1 (max)
+		clamp(dist, m_nearwall_dist_min, m_nearwall_dist_max);
+		float fDistanceMod = ((dist - m_nearwall_dist_min) / (m_nearwall_dist_max - m_nearwall_dist_min)); // 0.f ... 1.f
+
+		 // Рассчитываем базовый HUD FOV от бедра
+		float fBaseFov = psHUD_FOV_def;
+		clamp(fBaseFov, 0.0f, FLT_MAX);
+
+		// Плавно высчитываем итоговый FOV от бедра
+		float src = m_nearwall_speed_mod * Device.fTimeDelta;
+		clamp(src, 0.f, 1.f);
+
+		float fTrgFov = m_nearwall_target_hud_fov + fDistanceMod * (fBaseFov - m_nearwall_target_hud_fov);
+		m_nearwall_last_hud_fov = m_nearwall_last_hud_fov * (1 - src) + fTrgFov * src;
+	}
+
 	if (m_fZoomRotationFactor > 0.0f)
 	{
 		if (SecondVPEnabled() && m_fSecondVPHudFov > 0.0f)
 		{
 			// В линзе зума
-			float fDiff = psHUD_FOV_def - m_fSecondVPHudFov;
+			float fDiff = m_nearwall_last_hud_fov - m_fSecondVPHudFov;
 			return m_fSecondVPHudFov + (fDiff * (1 - m_fZoomRotationFactor));
 		}
 		if (!UseScopeTexture() && m_fZoomHudFov > 0.0f)
 		{
 			// В процессе зума
-			float fDiff = psHUD_FOV_def - m_fZoomHudFov;
+			float fDiff = m_nearwall_last_hud_fov - m_fZoomHudFov;
 			return m_fZoomHudFov + (fDiff * (1 - m_fZoomRotationFactor));
 		}
 	}
 
 	// От бедра	 
-	return psHUD_FOV_def;
+	return m_nearwall_last_hud_fov;
 }

--- a/ogsr_engine/xrGame/Weapon.h
+++ b/ogsr_engine/xrGame/Weapon.h
@@ -524,6 +524,16 @@ protected:
 	// therefore we should hold them by ourself :-((
 	float					m_addon_holder_range_modifier;
 	float					m_addon_holder_fov_modifier;
+
+	float m_nearwall_last_hud_fov;
+
+	float m_nearwall_target_hud_fov = 0.f;
+	float m_nearwall_dist_max = 0.f;
+	float m_nearwall_dist_min = 0.f;
+	float m_nearwall_speed_mod = 0.f;
+
+	bool m_nearwall_on = false;
+
 public:
 	virtual	void			modify_holder_params		(float &range, float &fov) const;
 	virtual bool			use_crosshair				()	const {return true;}
@@ -550,5 +560,3 @@ public:
 
 	void SwitchScope();
 };
-
-extern float default_fov;// = 67.5f;

--- a/ogsr_engine/xrGame/WeaponMagazined.cpp
+++ b/ogsr_engine/xrGame/WeaponMagazined.cpp
@@ -767,6 +767,8 @@ void CWeaponMagazined::switch2_Hidden()
 
 	signal_HideComplete		();
 	RemoveShotEffector		();
+
+	m_nearwall_last_hud_fov = psHUD_FOV_def;
 }
 void CWeaponMagazined::switch2_Showing()
 {

--- a/ogsr_engine/xrGame/WeaponMagazined.cpp
+++ b/ogsr_engine/xrGame/WeaponMagazined.cpp
@@ -972,6 +972,7 @@ void CWeaponMagazined::InitZoomParams(LPCSTR section, bool useTexture)
 		m_bScopeDynamicZoom = false;
 
 	m_fScopeInertionFactor = READ_IF_EXISTS(pSettings, r_float, section, "scope_inertion_factor", m_fControlInertionFactor);
+	clamp(m_fScopeInertionFactor, m_fControlInertionFactor, m_fScopeInertionFactor);
 
 	m_fScopeZoomFactor = pSettings->r_float(section, "scope_zoom_factor");
 	m_fSecondVPZoomFactor = READ_IF_EXISTS(pSettings, r_float, section, "scope_lense_fov_factor", 0.0f);

--- a/ogsr_engine/xrGame/level_changer.cpp
+++ b/ogsr_engine/xrGame/level_changer.cpp
@@ -182,12 +182,82 @@ void CLevelChanger::update_actor_invitation()
 #include "script_game_object.h"
 
 void CLevelChanger::ChangeLevel() {
-  Fvector p,r;
-  bool b = get_reject_pos( p, r );
-  CUIGameSP* pGameSP = smart_cast<CUIGameSP*>( HUD().GetUI()->UIGame() );
-  if( pGameSP ) {
-    Actor()->callback( GameObject::eLevelChangerAction )( lua_game_object(), (CUIWindow*)pGameSP->UIChangeLevelWnd );
-    pGameSP->ChangeLevel( m_game_vertex_id, m_level_vertex_id, m_position, m_angles, p, r, b );
-  }
+	Fvector p, r;
+	bool b = get_reject_pos(p, r);
+	CUIGameSP* pGameSP = smart_cast<CUIGameSP*>(HUD().GetUI()->UIGame());
+	if (pGameSP) {
+		Actor()->callback(GameObject::eLevelChangerAction)(lua_game_object(), (CUIWindow*)pGameSP->UIChangeLevelWnd);
+		pGameSP->ChangeLevel(m_game_vertex_id, m_level_vertex_id, m_position, m_angles, p, r, b);
+	}
 }
 
+
+#include "hudmanager.h"
+#include "Debug_Renderer.h"
+
+void CLevelChanger::OnRender()
+{
+	RCache.OnFrameEnd();
+	Fvector l_half; l_half.set(.5f, .5f, .5f);
+	Fmatrix l_ball, l_box;
+	xr_vector<CCF_Shape::shape_def> &l_shapes = ((CCF_Shape*)CFORM())->Shapes();
+	xr_vector<CCF_Shape::shape_def>::iterator l_pShape;
+
+	u32 Color = D3DCOLOR_XRGB(255, 0, 255);
+
+	for (l_pShape = l_shapes.begin(); l_shapes.end() != l_pShape; ++l_pShape)
+	{
+		switch (l_pShape->type)
+		{
+		case 0:
+		{
+			Fsphere &l_sphere = l_pShape->data.sphere;
+			l_ball.scale(l_sphere.R, l_sphere.R, l_sphere.R);
+			//l_ball.scale(1.f, 1.f, 1.f);
+			Fvector l_p; XFORM().transform(l_p, l_sphere.P);
+			l_ball.translate_add(l_p);
+			//l_ball.mul(XFORM(), l_ball);
+			//l_ball.mul(l_ball, XFORM());
+			Level().debug_renderer().draw_ellipse(l_ball, Color);
+		}
+		break;
+		case 1:
+		{
+			l_box.mul(XFORM(), l_pShape->data.box);
+			Level().debug_renderer().draw_obb(l_box, l_half, Color);
+		}
+		break;
+		}
+	}
+	if (Device.vCameraPosition.distance_to(XFORM().c) < 100.0f) {
+
+		//DRAW name
+
+		Fmatrix		res;
+		res.mul(Device.mFullTransform, XFORM());
+
+		Fvector4	v_res;
+
+		float		delta_height = 0.f;
+
+		// get up on 2 meters
+		Fvector shift;
+		static float gx = 0.0f;
+		static float gy = 2.0f;
+		static float gz = 0.0f;
+		shift.set(gx, gy, gz);
+		res.transform(v_res, shift);
+
+		// check if the object in sight
+		if (v_res.z < 0 || v_res.w < 0)										return;
+		if (v_res.x < -1.f || v_res.x > 1.f || v_res.y<-1.f || v_res.y>1.f) return;
+
+		// get real (x,y)
+		float x = (1.f + v_res.x) / 2.f * (Device.dwWidth);
+		float y = (1.f - v_res.y) / 2.f * (Device.dwHeight) - delta_height;
+
+		HUD().Font().pFontMedium->SetColor(0xffff0000);
+		HUD().Font().pFontMedium->OutSet(x, y -= delta_height);
+		HUD().Font().pFontMedium->OutNext(Name());
+	}
+}

--- a/ogsr_engine/xrGame/level_changer.h
+++ b/ogsr_engine/xrGame/level_changer.h
@@ -37,4 +37,6 @@ public:
 	virtual BOOL		feel_touch_contact	(CObject* O);
 
 	virtual bool		IsVisibleForZones() { return false;		}
+
+	void OnRender();
 };

--- a/ogsr_engine/xrGame/level_script.cpp
+++ b/ogsr_engine/xrGame/level_script.cpp
@@ -380,6 +380,15 @@ void show_indicators()
 	HUD().GetUI()->ShowCrosshair();
 }
 
+bool game_indicators_shown()
+{
+	return HUD().GetUI()->GameIndicatorsShown();
+}
+
+Flags32 get_hud_flags()
+{
+	return psHUD_Flags;
+}
 
 bool is_level_present()
 {
@@ -1006,6 +1015,8 @@ void CLevel::script_register(lua_State *L)
 		def("main_input_receiver",				main_input_receiver),
 		def("hide_indicators",					hide_indicators),
 		def("show_indicators",					show_indicators),
+		def("game_indicators_shown",			game_indicators_shown),
+		def("get_hud_flags",					get_hud_flags),
 		def("add_call",							((CPHCall* (*) (const luabind::functor<bool> &,const luabind::functor<void> &)) &add_call)),
 		def("add_call",							((CPHCall* (*) (const luabind::object &,const luabind::functor<bool> &,const luabind::functor<void> &)) &add_call)),
 		def("add_call",							((CPHCall* (*) (const luabind::object &, LPCSTR, LPCSTR)) &add_call)),

--- a/ogsr_engine/xrGame/ui/MMSound.cpp
+++ b/ogsr_engine/xrGame/ui/MMSound.cpp
@@ -12,7 +12,6 @@ CMMSound::~CMMSound(){
 
 void CMMSound::Init(CUIXml& xml_doc, LPCSTR path){
 	string256 _path;	
-	m_bRandom = xml_doc.ReadAttribInt(path, 0, "random")? true : false;
 
 	int nodes_num	= xml_doc.GetNodesNum(path, 0, "menu_music");
 
@@ -77,7 +76,7 @@ void CMMSound::music_Play(){
 }
 
 void CMMSound::music_Update(){
-	if (Device.Paused()) return;
+
 	if (0==m_music_l._feedback() || 0==m_music_r._feedback())
 		music_Play();
 }

--- a/ogsr_engine/xrGame/ui/MMSound.h
+++ b/ogsr_engine/xrGame/ui/MMSound.h
@@ -25,6 +25,5 @@ protected:
 	ref_sound		m_music_r;
 	ref_sound		m_whell;
 	ref_sound		m_whell_click;
-	bool			m_bRandom;
 	xr_vector<xr_string>m_play_list;
 };

--- a/ogsr_engine/xrGame/ui/UIMainIngameWnd.cpp
+++ b/ogsr_engine/xrGame/ui/UIMainIngameWnd.cpp
@@ -134,8 +134,7 @@ CUIMainIngameWnd::CUIMainIngameWnd()
 	UIZoneMap					= xr_new<CUIZoneMap>();
 	m_pPickUpItem				= NULL;
 	m_artefactPanel				= xr_new<CUIArtefactPanel>();
-	m_pMPChatWnd				= NULL;
-	m_pMPLogWnd					= NULL;	
+
 	warn_icon_list[ewiWeaponJammed]	= &UIWeaponJammedIcon;	
 	warn_icon_list[ewiRadiation]	= &UIRadiaitionIcon;
 	warn_icon_list[ewiWound]		= &UIWoundIcon;
@@ -345,12 +344,6 @@ void CUIMainIngameWnd::Draw()
 #endif
 }
 
-
-void CUIMainIngameWnd::SetMPChatLog(CUIWindow* pChat, CUIWindow* pLog){
-	m_pMPChatWnd = pChat;
-	m_pMPLogWnd  = pLog;
-}
-
 void CUIMainIngameWnd::SetAmmoIcon (const shared_str& sect_name)
 {
 	if ( !sect_name.size() )
@@ -388,12 +381,6 @@ void CUIMainIngameWnd::Update()
 #ifdef DEBUG
 	test_update();
 #endif
-	if (m_pMPChatWnd)
-		m_pMPChatWnd->Update();
-	if (m_pMPLogWnd)
-		m_pMPLogWnd->Update();
-
-
 
 	m_pActor = smart_cast<CActor*>(Level().CurrentViewEntity());
 	if (!m_pActor) 

--- a/ogsr_engine/xrGame/ui/UIMainIngameWnd.h
+++ b/ogsr_engine/xrGame/ui/UIMainIngameWnd.h
@@ -99,13 +99,11 @@ public:
 		ewiWound,
 		ewiStarvation,
 		ewiPsyHealth,
-		ewiThirst,
 		ewiInvincible,
+		ewiThirst,
 //		ewiSleep,
 //		ewiArtefact,
 	};
-
-	void				SetMPChatLog					(CUIWindow* pChat, CUIWindow* pLog);
 
 	// Задаем цвет соответствующей иконке
 	void				SetWarningIconColor				(EWarningIcons icon, const u32 cl);

--- a/ogsr_engine/xrGame/ui/UIMainIngameWnd.h
+++ b/ogsr_engine/xrGame/ui/UIMainIngameWnd.h
@@ -85,8 +85,6 @@ protected:
 //	CUIStatic			UIArtefactIcon;
 
 	CUIScrollView*		m_UIIcons;
-	CUIWindow*			m_pMPChatWnd;
-	CUIWindow*			m_pMPLogWnd;
 public:	
 	CUIArtefactPanel*    m_artefactPanel;
 	

--- a/ogsr_engine/xrGame/ui/ui_af_params.cpp
+++ b/ogsr_engine/xrGame/ui/ui_af_params.cpp
@@ -44,6 +44,7 @@ LPCSTR af_item_param_names[] = {
 	"ui_inv_health",
 	"ui_inv_radiation",
 	"ui_inv_satiety",
+	"ui_inv_thirst",
 	"ui_inv_power",
 	"ui_inv_bleeding",
 	"ui_inv_psy_health",


### PR DESCRIPTION
* Изменение HUD FOV когда игрок стоит вплотную к стене (from Shoker)
Параметры в секции оружия:
```
nearwall_on - включение (умолчание false)
nearwall_target_hud_fov - HUD FOV когда ГГ полностью уперся в стену
nearwall_dist_min - мин расстояние когда уже дошли до nearwall_target_hud_fov
nearwall_dist_max - макс расстояние с которого текущий HUD FOV начинает меняться к целевому nearwall_target_hud_fov
nearwall_speed_mod - скорость изменения HUD FOV
```
* Добавил экспорт для **psHUD_Flags - level.get_hud_flags()** и **HUD().GetUI()->GameIndicatorsShown() - level.game_indicators_shown()**
Константы для добавления в _g.script (пока не делал экспорт)
HUD_CROSSHAIR   = 1 * 2 ^ 0
HUD_CROSSHAIR_DIST  = 1 * 2 ^ 1
HUD_WEAPON    = 1 * 2 ^ 2
HUD_INFO    = 1 * 2 ^ 3
HUD_DRAW    = 1 * 2 ^ 4
HUD_CROSSHAIR_RT  = 1 * 2 ^ 5
HUD_WEAPON_RT   = 1 * 2 ^ 6
HUD_CROSSHAIR_DYNAMIC = 1 * 2 ^ 7
HUD_CROSSHAIR_RT2  = 1 * 2 ^ 9
HUD_DRAW_RT    = 1 * 2 ^ 10
HUD_CROSSHAIR_BUILD  = 1 * 2 ^ 11
Нормальный (копия движкового) способ проверить что игра показывает худ:
```
function hud_present()
    local hud_present = level.game_indicators_shown() and level.get_hud_flags():is(bit_or(HUD_DRAW, HUD_DRAW_RT))
    return hud_present
end
```
* Добавил параметр **jump_require_power** (по умолчанию false) в секцию actor_condition актора. Если включен - перед прыжком будет проверяться, что ГГ имеет достаточно силы для прыжка с учетом веса рюкзака.
* Теперь **scope_inertion_factor** будет учитывать текущее значение зума для оружия с **scope_dynamic_zoom**
* Поправил музыку в главном меню - теперь треки будут играть вечно
* Добавил отображение CLevelChanger при g_zones_dbg
* Правки для худа из за actor_thirst