### PR TITLE
Добавил поддержку чтение patrol_path из ltx файлов напрямую

### DIFF
--- a/ogsr_engine/COMMON_AI/PATH/patrol_path.cpp
+++ b/ogsr_engine/COMMON_AI/PATH/patrol_path.cpp
@@ -42,7 +42,7 @@ CPatrolPath	&CPatrolPath::load_raw	(const CLevelGraph *level_graph, const CGameL
 
 CPatrolPath	&CPatrolPath::load_ini(CInifile::Sect& section)
 {
-	const LPCSTR points = section.r_string("points");
+	const char* points = section.r_string("points");
 	const int vertex_count = _GetItemCount(points);
 
 	string16 prefix;
@@ -62,7 +62,7 @@ CPatrolPath	&CPatrolPath::load_ini(CInifile::Sect& section)
 
 		if (section.line_exist(full_name))
 		{
-			const LPCSTR links = section.r_string(full_name);
+			const char* links = section.r_string(full_name);
 			const int links_count = _GetItemCount(links);
 
 			string32 link;

--- a/ogsr_engine/COMMON_AI/PATH/patrol_path.cpp
+++ b/ogsr_engine/COMMON_AI/PATH/patrol_path.cpp
@@ -10,13 +10,15 @@
 #include "patrol_path.h"
 #include "levelgamedef.h"
 
-LPCSTR TEST_PATROL_PATH_NAME		= "val_dogs_nest4_centre";
-
 CPatrolPath::CPatrolPath			(shared_str name)
 {
 #ifdef DEBUG
 	m_name			= name;
 #endif
+}
+
+CPatrolPath::~CPatrolPath()
+{
 }
 
 CPatrolPath	&CPatrolPath::load_raw	(const CLevelGraph *level_graph, const CGameLevelCrossTable *cross, const CGameGraph *game_graph, IReader &stream)
@@ -38,8 +40,47 @@ CPatrolPath	&CPatrolPath::load_raw	(const CLevelGraph *level_graph, const CGameL
 	return			(*this);
 }
 
-CPatrolPath::~CPatrolPath	()
+CPatrolPath	&CPatrolPath::load_ini(CInifile::Sect& section)
 {
+	const LPCSTR points = section.r_string("points");
+	const int vertex_count = _GetItemCount(points);
+
+	string16 prefix;
+	for (int i = 0; i < vertex_count; ++i)
+	{
+		_GetItem(points, i, prefix);
+
+		add_vertex(CPatrolPoint(this).load_ini(section, prefix), i);
+	}
+
+	for (int i = 0; i < vertex_count; ++i)
+	{
+		_GetItem(points, i, prefix);
+
+		string256 full_name;
+		strconcat(sizeof(full_name), full_name, prefix, ":", "links");
+
+		if (section.line_exist(full_name))
+		{
+			const LPCSTR links = section.r_string(full_name);
+			const int links_count = _GetItemCount(links);
+
+			string32 link;
+			for (int k = 0; k < links_count; ++k)
+			{
+				_GetItem(links, k, link);
+
+				u32 vertex_idx;
+				float probability;
+
+				sscanf(link, "p%d(%f)", &vertex_idx, &probability);
+
+				add_edge(i, vertex_idx, probability);
+			}
+		}
+	}
+
+	return			(*this);
 }
 
 #ifdef DEBUG

--- a/ogsr_engine/COMMON_AI/PATH/patrol_path.h
+++ b/ogsr_engine/COMMON_AI/PATH/patrol_path.h
@@ -33,6 +33,7 @@ public:
 							CPatrolPath		(shared_str name = "");
 	virtual					~CPatrolPath	();
 			CPatrolPath		&load_raw		(const CLevelGraph *level_graph, const CGameLevelCrossTable *cross, const CGameGraph *game_graph, IReader &stream);
+			CPatrolPath		&load_ini		(CInifile::Sect& section);
 	IC		const CVertex	*point			(shared_str name) const;
 	template <typename T>
 	IC		const CVertex	*point			(const Fvector &position, const T &evaluator) const;

--- a/ogsr_engine/COMMON_AI/PATH/patrol_path_storage.cpp
+++ b/ogsr_engine/COMMON_AI/PATH/patrol_path_storage.cpp
@@ -54,6 +54,38 @@ void CPatrolPathStorage::load_raw			(const CLevelGraph *level_graph, const CGame
 	chunk->close				();
 }
 
+void CPatrolPathStorage::append_from_ini(CInifile &way_inifile)
+{
+	PATROL_REGISTRY::value_type	pair;
+
+	int i = 0;
+	int r = 0;
+	for (const auto &it : way_inifile.sections())
+	{
+		const shared_str patrol_name = it.first;
+
+		if (m_registry.erase(patrol_name))
+		{
+			r++;
+		}
+
+		m_registry.insert(
+			std::make_pair(
+				patrol_name,
+				&xr_new<CPatrolPath>(
+					patrol_name
+					)->load_ini(
+						*it.second
+					)
+			)
+		);
+
+		i++;
+	}
+
+	Msg("Loaded %d items from custom_waypoints, %d from all.spawn was replaced!", i, r);
+}
+
 void CPatrolPathStorage::load				(IReader &stream)
 {
 	IReader						*chunk;

--- a/ogsr_engine/COMMON_AI/PATH/patrol_path_storage.h
+++ b/ogsr_engine/COMMON_AI/PATH/patrol_path_storage.h
@@ -36,6 +36,7 @@ public:
 
 public:
 			void					load_raw			(const CLevelGraph *level_graph, const CGameLevelCrossTable *cross, const CGameGraph *game_graph, IReader &stream);
+			void					append_from_ini		(CInifile &way_inifile);
 	IC		const CPatrolPath		*path				(shared_str patrol_name, bool no_assert = false) const;
 	IC		const PATROL_REGISTRY	&patrol_paths		() const;
 	void add_path( shared_str, CPatrolPath* );

--- a/ogsr_engine/COMMON_AI/PATH/patrol_point.cpp
+++ b/ogsr_engine/COMMON_AI/PATH/patrol_point.cpp
@@ -94,6 +94,34 @@ CPatrolPoint &CPatrolPoint::load_raw						(const CLevelGraph *level_graph, const
 	return				(*this);
 }
 
+Fvector3 r_fvector3(CInifile::Sect& section, LPCSTR L) {
+	LPCSTR   C = section.r_string(L);
+	Fvector3 V = { 0.f, 0.f, 0.f };
+	sscanf(C, "%f,%f,%f", &V.x, &V.y, &V.z);
+	return V;
+}
+
+CPatrolPoint &CPatrolPoint::load_ini(CInifile::Sect& section, LPSTR prefix)
+{
+	string256 full_name;
+
+	m_name				= section.r_string(strconcat(sizeof(full_name), full_name, prefix, ":", "name"));
+	m_position			= r_fvector3(section, strconcat(sizeof(full_name), full_name, prefix, ":", "position"));
+	m_level_vertex_id	= strtol(section.r_string(strconcat(sizeof(full_name), full_name, prefix, ":", "level_vertex_id")), nullptr, 10);
+	m_game_vertex_id	= strtol(section.r_string(strconcat(sizeof(full_name), full_name, prefix, ":", "game_vertex_id")), nullptr, 10);
+
+	strconcat(sizeof(full_name), full_name, prefix, ":", "flags");
+
+	if (section.line_exist(full_name))
+		m_flags = strtol(section.r_string(full_name), nullptr, 16);
+
+#ifdef DEBUG
+	m_initialized = true;
+#endif
+	// correct_position(level_graph, cross, game_graph); ???
+	return				(*this);
+}
+
 void CPatrolPoint::load										(IReader &stream)
 {
 	load_data			(m_name,stream);

--- a/ogsr_engine/COMMON_AI/PATH/patrol_point.cpp
+++ b/ogsr_engine/COMMON_AI/PATH/patrol_point.cpp
@@ -105,12 +105,12 @@ CPatrolPoint &CPatrolPoint::load_ini(CInifile::Sect& section, LPSTR prefix)
 {
 	string256 full_name;
 
-	m_name				= section.r_string(strconcat(sizeof(full_name), full_name, prefix, ":", "name"));
-	m_position			= r_fvector3(section, strconcat(sizeof(full_name), full_name, prefix, ":", "position"));
-	m_level_vertex_id	= strtol(section.r_string(strconcat(sizeof(full_name), full_name, prefix, ":", "level_vertex_id")), nullptr, 10);
-	m_game_vertex_id	= strtol(section.r_string(strconcat(sizeof(full_name), full_name, prefix, ":", "game_vertex_id")), nullptr, 10);
+	m_name				= section.r_string(xr_strconcat(full_name, prefix, ":", "name"));
+	m_position			= r_fvector3(section, xr_strconcat(full_name, prefix, ":", "position"));
+	m_level_vertex_id	= strtol(section.r_string(xr_strconcat(full_name, prefix, ":", "level_vertex_id")), nullptr, 10);
+	m_game_vertex_id	= strtol(section.r_string(xr_strconcat(full_name, prefix, ":", "game_vertex_id")), nullptr, 10);
 
-	strconcat(sizeof(full_name), full_name, prefix, ":", "flags");
+	xr_strconcat(full_name, prefix, ":", "flags");
 
 	if (section.line_exist(full_name))
 		m_flags = strtol(section.r_string(full_name), nullptr, 16);

--- a/ogsr_engine/COMMON_AI/PATH/patrol_point.h
+++ b/ogsr_engine/COMMON_AI/PATH/patrol_point.h
@@ -44,6 +44,7 @@ public:
 	virtual	void						load				(IReader &stream);
 	virtual	void						save				(IWriter &stream);
 			CPatrolPoint				&load_raw			(const CLevelGraph *level_graph, const CGameLevelCrossTable *cross, const CGameGraph *game_graph, IReader &stream);
+			CPatrolPoint				&load_ini			(CInifile::Sect& section, LPSTR prefix);
 	IC		const Fvector				&position			() const;
 	IC		const u32					&level_vertex_id	(const CLevelGraph *level_graph, const CGameLevelCrossTable *cross, const CGameGraph *game_graph) const;
 	IC		const GameGraph::_GRAPH_ID	&game_vertex_id		(const CLevelGraph *level_graph, const CGameLevelCrossTable *cross, const CGameGraph *game_graph) const;

--- a/ogsr_engine/xrCore/Xr_ini.cpp
+++ b/ogsr_engine/xrCore/Xr_ini.cpp
@@ -77,7 +77,7 @@ LPCSTR CInifile::Sect::r_string( LPCSTR L ) {
 	if (A != Data.end())
 		return A->second.c_str();
 	else
-		Debug.fatal(DEBUG_INFO, "Can't find variable %s in [%s]", L, Name.c_str());
+		FATAL("Can't find variable %s in [%s]", L, Name.c_str());
 	return 0;
 }
 
@@ -174,7 +174,7 @@ void CInifile::Load ( IReader* F, LPCSTR path ) {
       if ( Current ) {
         auto I = DATA.find( Current->Name );
         if ( I != DATA.end() )
-          Debug.fatal( DEBUG_INFO, "Duplicate section '%s' found.", Current->Name.c_str() );
+          FATAL( "Duplicate section '%s' found.", Current->Name.c_str() );
         DATA.insert({ Current->Name, Current });
       }
       Current = xr_new<Sect>();
@@ -233,7 +233,7 @@ void CInifile::Load ( IReader* F, LPCSTR path ) {
   if ( Current ) {
     auto I = DATA.find( Current->Name );
     if ( I != DATA.end() )
-      Debug.fatal( DEBUG_INFO, "Duplicate section '%s' found.", Current->Name.c_str() );
+      FATAL( "Duplicate section '%s' found.", Current->Name.c_str() );
     DATA.insert({ Current->Name, Current });
   }
 }
@@ -333,7 +333,7 @@ CInifile::Sect& CInifile::r_section( LPCSTR S ) {
   shared_str k = strlwr( section );
   const auto I = DATA.find( k );
   if ( I == DATA.end() )
-    Debug.fatal( DEBUG_INFO, "Can't open section '%s'", S );
+    FATAL( "Can't open section '%s'", S );
   return  *I->second;
 }
 
@@ -347,7 +347,7 @@ LPCSTR CInifile::r_string ( LPCSTR S, LPCSTR L ) {
   if ( A != I.Data.end() )
     return A->second.c_str();
   else
-    Debug.fatal( DEBUG_INFO, "Can't find variable %s in [%s]", L, S );
+    FATAL( "Can't find variable %s in [%s]", L, S );
   return 0;
 }
 

--- a/ogsr_engine/xrCore/Xr_ini.cpp
+++ b/ogsr_engine/xrCore/Xr_ini.cpp
@@ -68,6 +68,18 @@ BOOL CInifile::Sect::line_exist( LPCSTR L, LPCSTR* val ) {
   return FALSE;
 }
 
+LPCSTR CInifile::Sect::r_string( LPCSTR L ) {
+	if (!L || !strlen(L)) //--#SM+#-- [fix for one of "xrDebug - Invalid handler" error log]
+		Msg("!![ERROR] CInifile::Sect::r_string: S = [%s], L = [%s]", Name.c_str(), L);
+
+	shared_str k(L);
+	const auto A = Data.find(k);
+	if (A != Data.end())
+		return A->second.c_str();
+	else
+		Debug.fatal(DEBUG_INFO, "Can't find variable %s in [%s]", L, Name.c_str());
+	return 0;
+}
 
 CInifile::CInifile( IReader* F, LPCSTR path ) {
   fName      = 0;
@@ -324,7 +336,6 @@ CInifile::Sect& CInifile::r_section( LPCSTR S ) {
     Debug.fatal( DEBUG_INFO, "Can't open section '%s'", S );
   return  *I->second;
 }
-
 
 LPCSTR CInifile::r_string ( LPCSTR S, LPCSTR L ) {
   if ( !S || !L || !strlen( S ) || !strlen( L ) ) //--#SM+#-- [fix for one of "xrDebug - Invalid handler" error log]

--- a/ogsr_engine/xrCore/xr_ini.h
+++ b/ogsr_engine/xrCore/xr_ini.h
@@ -11,6 +11,7 @@ class XRCORE_API CInifile {
     string_unordered_map<shared_str, shared_str> Data;
     std::vector<Item> Unordered;
     BOOL line_exist ( LPCSTR, LPCSTR* = nullptr );
+	LPCSTR r_string( LPCSTR );
   };
   using Root = string_unordered_map<shared_str, Sect*>;
 

--- a/ogsr_engine/xrGame/GameTask.cpp
+++ b/ogsr_engine/xrGame/GameTask.cpp
@@ -142,7 +142,7 @@ void CGameTask::Load(const TASK_ID& id)
 //*
 		LPCSTR ddd;
 		ddd								= g_gameTaskXml->Read(l_root, "map_location_hidden", 0, NULL);
-		if ( ddd || !m_show_all_objectives )
+		if ( (ddd || !m_show_all_objectives) && i > 1) // первая точка в квесте не может быть скрытая
 			objective.def_location_enabled = false;
 
 		bool b1,b2;

--- a/ogsr_engine/xrGame/WeaponMagazined.cpp
+++ b/ogsr_engine/xrGame/WeaponMagazined.cpp
@@ -1001,7 +1001,6 @@ void CWeaponMagazined::InitAddons()
 	// Прицел
 	m_fIronSightZoomFactor = READ_IF_EXISTS(pSettings, r_float, cNameSect(), "ironsight_zoom_factor", 50.0f);
 	m_fSecondScopeZoomFactor = READ_IF_EXISTS(pSettings, r_float, cNameSect(), "second_scope_zoom_factor", m_fIronSightZoomFactor);
-	//
 
 	if(IsScopeAttached())
 	{
@@ -1012,6 +1011,9 @@ void CWeaponMagazined::InitAddons()
 			m_iScopeY = pSettings->r_s32(cNameSect(), "scope_y");
 
 			InitZoomParams(*m_sScopeName, true);
+
+			m_fZoomHudFov = READ_IF_EXISTS(pSettings, r_float, cNameSect(), "scope_zoom_hud_fov", m_fZoomHudFov);
+			m_fSecondVPHudFov = READ_IF_EXISTS(pSettings, r_float, cNameSect(), "scope_lense_hud_fov", m_fSecondVPHudFov);
 		}
 		else if(m_eScopeStatus == ALife::eAddonPermanent)
 		{
@@ -1031,7 +1033,6 @@ void CWeaponMagazined::InitAddons()
 
 			// for weapon without any scope - scope_zoom_factor will overrider ironsight_zoom_factor
 			m_fIronSightZoomFactor = m_fScopeZoomFactor;
-
 		}
 		else 
 		{
@@ -1073,7 +1074,6 @@ void CWeaponMagazined::InitAddons()
 		m_sSmokeParticlesCurrent = m_sSilencerSmokeParticles;
 		m_pSndShotCurrent = &sndSilencerShot;
 
-
 		//сила выстрела
 		LoadFireParams	(*cNameSect(), "");
 
@@ -1090,6 +1090,7 @@ void CWeaponMagazined::InitAddons()
 
 		//сила выстрела
 		LoadFireParams	(*cNameSect(), "");
+
 		//подсветка от выстрела
 		LoadLights		(*cNameSect(), "");
 	}

--- a/ogsr_engine/xrGame/ai_space.cpp
+++ b/ogsr_engine/xrGame/ai_space.cpp
@@ -200,6 +200,11 @@ void CAI_Space::patrol_path_storage		(IReader &stream)
 	m_patrol_path_storage->load		(stream);
 }
 
+void CAI_Space::patrol_path_storage_ini(CInifile &way_inifile)
+{
+	m_patrol_path_storage->append_from_ini(way_inifile);
+}
+
 void CAI_Space::set_alife				(CALifeSimulator *alife_simulator)
 {
 	VERIFY					((!m_alife_simulator && alife_simulator) || (m_alife_simulator && !alife_simulator));

--- a/ogsr_engine/xrGame/ai_space.h
+++ b/ogsr_engine/xrGame/ai_space.h
@@ -44,6 +44,7 @@ private:
 			void						unload					(bool reload = false);
 			void						patrol_path_storage_raw	(IReader &stream);
 			void						patrol_path_storage		(IReader &stream);
+			void						patrol_path_storage_ini	(CInifile &way_inifile);
 			void						set_alife				(CALifeSimulator *alife_simulator);
 
 #ifdef PRIQUEL

--- a/ogsr_engine/xrGame/alife_simulator_base.cpp
+++ b/ogsr_engine/xrGame/alife_simulator_base.cpp
@@ -304,17 +304,18 @@ void CALifeSimulatorBase::append_item_vector(OBJECT_VECTOR &tObjectVector, ITEM_
 void CALifeSimulatorBase::assign_death_position(CSE_ALifeCreatureAbstract *tpALifeCreatureAbstract, GameGraph::_GRAPH_ID tGraphID, CSE_ALifeSchedulable *tpALifeSchedulable)
 {
 	tpALifeCreatureAbstract->fHealth		= 0;
-	
-	if (tpALifeSchedulable) {
-		CSE_ALifeAnomalousZone				*l_tpALifeAnomalousZone = smart_cast<CSE_ALifeAnomalousZone*>(tpALifeSchedulable);
-		if (l_tpALifeAnomalousZone) {
-			spawns().assign_artefact_position(l_tpALifeAnomalousZone,tpALifeCreatureAbstract);
-			CSE_ALifeMonsterAbstract		*l_tpALifeMonsterAbstract = smart_cast<CSE_ALifeMonsterAbstract*>(tpALifeCreatureAbstract);
-			if (l_tpALifeMonsterAbstract)
-				l_tpALifeMonsterAbstract->m_tPrevGraphID = l_tpALifeMonsterAbstract->m_tNextGraphID = l_tpALifeMonsterAbstract->m_tGraphID;
-			return;
-		}
-	}
+
+	// tpALifeSchedulable всегда 0
+	//if (tpALifeSchedulable) {
+	//	CSE_ALifeAnomalousZone				*l_tpALifeAnomalousZone = smart_cast<CSE_ALifeAnomalousZone*>(tpALifeSchedulable);
+	//	if (l_tpALifeAnomalousZone) {
+	//		spawns().assign_artefact_position(l_tpALifeAnomalousZone,tpALifeCreatureAbstract);
+	//		CSE_ALifeMonsterAbstract		*l_tpALifeMonsterAbstract = smart_cast<CSE_ALifeMonsterAbstract*>(tpALifeCreatureAbstract);
+	//		if (l_tpALifeMonsterAbstract)
+	//			l_tpALifeMonsterAbstract->m_tPrevGraphID = l_tpALifeMonsterAbstract->m_tNextGraphID = l_tpALifeMonsterAbstract->m_tGraphID;
+	//		return;
+	//	}
+	//}
 
 	CGameGraph::const_spawn_iterator		i, e;
 	ai().game_graph().begin_spawn			(tGraphID,i,e);

--- a/ogsr_engine/xrGame/alife_simulator_script.cpp
+++ b/ogsr_engine/xrGame/alife_simulator_script.cpp
@@ -410,6 +410,11 @@ LPCSTR get_loaded_save(CALifeSimulator *sim)
 	return result ? result : "NULL";
 }
 
+bool is_unloading(CALifeSimulator *sim)
+{
+	return sim->is_unloading();
+}
+
 #pragma optimize("s",on)
 void CALifeSimulator::script_register			(lua_State *L)
 {
@@ -423,6 +428,7 @@ void CALifeSimulator::script_register			(lua_State *L)
 			.def("object",					(CSE_ALifeDynamicObject *(*) (const CALifeSimulator *,ALife::_OBJECT_ID))(alife_object))
 			.def("object",					(CSE_ALifeDynamicObject *(*) (const CALifeSimulator *,LPCSTR))(alife_object))
 			.def("object",					(CSE_ALifeDynamicObject *(*) (const CALifeSimulator *,ALife::_OBJECT_ID, bool))(alife_object))
+			.def("is_unloading",			&is_unloading)
 			.def("story_object",			(CSE_ALifeDynamicObject *(*) (const CALifeSimulator *,ALife::_STORY_ID))(alife_story_object))
 			.def("set_switch_online",		(void (CALifeSimulator::*) (ALife::_OBJECT_ID,bool))(&CALifeSimulator::set_switch_online))
 			.def("set_switch_offline",		(void (CALifeSimulator::*) (ALife::_OBJECT_ID,bool))(&CALifeSimulator::set_switch_offline))

--- a/ogsr_engine/xrGame/alife_spawn_registry.cpp
+++ b/ogsr_engine/xrGame/alife_spawn_registry.cpp
@@ -50,7 +50,7 @@ void CALifeSpawnRegistry::save				(IWriter &memory_stream)
 	memory_stream.close_chunk	();
 	
 	memory_stream.open_chunk	(1);
-	save_updates				(memory_stream);
+	// save_updates				(memory_stream); ???
 	memory_stream.close_chunk	();
 
 	memory_stream.close_chunk	();
@@ -143,14 +143,30 @@ void CALifeSpawnRegistry::load				(IReader &file_stream, xrGUID *save_guid)
 	}
 #endif
 
-	chunk						= file_stream.open_chunk(2);
+	/*chunk						= file_stream.open_chunk(2);
 	load_data					(m_artefact_spawn_positions,*chunk);
-	chunk->close				();
+	chunk->close				();*/
 
 	chunk						= file_stream.open_chunk(3);
 	R_ASSERT2					(chunk,"Spawn version mismatch - REBUILD SPAWN!");
 	ai().patrol_path_storage	(*chunk);
 	chunk->close				();
+
+	if (pSettings->line_exist("engine_custom_spawn", "waypoints_file"))
+	{	
+		string_path fname;
+		FS.update_path(fname, "$game_config$", pSettings->r_string("engine_custom_spawn", "waypoints_file"));
+
+		if (FS.exist(fname))
+		{
+			Msg("Start load of custom waypoints...");
+
+			CInifile way_inifile = CInifile(fname);
+			ai().patrol_path_storage_ini(way_inifile);
+
+			Msg("End load of custom waypoints...");
+		}
+	}
 
 #ifdef PRIQUEL
 	VERIFY						(!m_chunk);
@@ -171,27 +187,27 @@ void CALifeSpawnRegistry::load				(IReader &file_stream, xrGUID *save_guid)
 	Msg							("* %d spawn points are successfully loaded",m_spawns.vertex_count());
 }
 
-void CALifeSpawnRegistry::save_updates		(IWriter &stream)
-{
-	SPAWN_GRAPH::vertex_iterator			I = m_spawns.vertices().begin();
-	SPAWN_GRAPH::vertex_iterator			E = m_spawns.vertices().end();
-	for ( ; I != E; ++I) {
-		stream.open_chunk					((*I).second->vertex_id());
-		(*I).second->data()->save_update	(stream);
-		stream.close_chunk					();
-	}
-}
-
-void CALifeSpawnRegistry::load_updates		(IReader &stream)
-{
-	u32								vertex_id;
-	for (IReader *chunk = stream.open_chunk_iterator(vertex_id); chunk; chunk = stream.open_chunk_iterator(vertex_id,chunk)) {
-		VERIFY						(u32(ALife::_SPAWN_ID(-1)) > vertex_id);
-		const SPAWN_GRAPH::CVertex	*vertex = m_spawns.vertex(ALife::_SPAWN_ID(vertex_id));
-		VERIFY						(vertex);
-		vertex->data()->load_update	(*chunk);
-	}
-}
+//void CALifeSpawnRegistry::save_updates		(IWriter &stream)
+//{
+//	SPAWN_GRAPH::vertex_iterator			I = m_spawns.vertices().begin();
+//	SPAWN_GRAPH::vertex_iterator			E = m_spawns.vertices().end();
+//	for ( ; I != E; ++I) {
+//		stream.open_chunk					((*I).second->vertex_id());
+//		(*I).second->data()->save_update	(stream);
+//		stream.close_chunk					();
+//	}
+//}
+//
+//void CALifeSpawnRegistry::load_updates		(IReader &stream)
+//{
+//	u32								vertex_id;
+//	for (IReader *chunk = stream.open_chunk_iterator(vertex_id); chunk; chunk = stream.open_chunk_iterator(vertex_id,chunk)) {
+//		VERIFY						(u32(ALife::_SPAWN_ID(-1)) > vertex_id);
+//		const SPAWN_GRAPH::CVertex	*vertex = m_spawns.vertex(ALife::_SPAWN_ID(vertex_id));
+//		VERIFY						(vertex);
+//		vertex->data()->load_update	(*chunk);
+//	}
+//}
 
 void CALifeSpawnRegistry::build_root_spawns	()
 {

--- a/ogsr_engine/xrGame/alife_spawn_registry.h
+++ b/ogsr_engine/xrGame/alife_spawn_registry.h
@@ -30,7 +30,7 @@ public:
 private:
 	CALifeSpawnHeader						m_header;
 	SPAWN_GRAPH								m_spawns;
-	ARTEFACT_SPAWNS							m_artefact_spawn_positions;
+	//ARTEFACT_SPAWNS							m_artefact_spawn_positions;
 	shared_str								m_spawn_name;
 	SPAWN_IDS								m_spawn_roots;
 	SPAWN_IDS								m_temp0;
@@ -45,22 +45,19 @@ private:
 #endif // PRIQUEL
 
 protected:
-			void							save_updates				(IWriter &stream);
-			void							load_updates				(IReader &stream);
+			//void							save_updates				(IWriter &stream);
+			//void							load_updates				(IReader &stream);
 			void							build_story_spawns			();
 			void							build_root_spawns			();
-			void							fill_new_spawns_single		(SPAWN_GRAPH::CVertex *vertex, xr_vector<ALife::_SPAWN_ID> &spawns, ALife::_TIME_ID game_time, xr_vector<ALife::_SPAWN_ID> &objects);
-			void							fill_new_spawns				(SPAWN_GRAPH::CVertex *vertex, xr_vector<ALife::_SPAWN_ID> &spawns, ALife::_TIME_ID game_time, xr_vector<ALife::_SPAWN_ID> &objects);
+			void							fill_new_spawns_single		(SPAWN_GRAPH::CVertex *vertex, xr_vector<ALife::_SPAWN_ID> &spawns, ALife::_TIME_ID game_time);
+			void							fill_new_spawns				(SPAWN_GRAPH::CVertex *vertex, xr_vector<ALife::_SPAWN_ID> &spawns, ALife::_TIME_ID game_time);
 	IC		void							process_spawns				(xr_vector<ALife::_SPAWN_ID> &spawns);
-	IC		bool							redundant					(CSE_Abstract &abstract);
-	IC		bool							new_spawn					(CSE_Abstract &abstract);
 	IC		bool							enabled_spawn				(CSE_Abstract &abstract) const;
 	IC		bool							count_limit					(CSE_Abstract &abstract) const;
 	IC		bool							time_limit					(CSE_Abstract &abstract, ALife::_TIME_ID game_time) const;
-	IC		bool							spawned_item				(CSE_Abstract &abstract, xr_vector<ALife::_SPAWN_ID> &objects) const;
-	IC		bool							spawned_item				(SPAWN_GRAPH::CVertex *vertex, xr_vector<ALife::_SPAWN_ID> &objects);
-	IC		bool							object_existance_limit		(CSE_Abstract &abstract, xr_vector<ALife::_SPAWN_ID> &objects) const;
-	IC		bool							can_spawn					(CSE_Abstract &abstract, ALife::_TIME_ID game_time, xr_vector<ALife::_SPAWN_ID> &objects) const;
+	IC		bool							spawned_item				(SPAWN_GRAPH::CVertex *vertex);
+	IC		bool							object_existance_limit		(CSE_Abstract &abstract) const;
+	IC		bool							can_spawn					(CSE_Abstract &abstract, ALife::_TIME_ID game_time) const;
 
 public:
 											CALifeSpawnRegistry			(LPCSTR section);
@@ -69,10 +66,10 @@ public:
 	virtual void							save						(IWriter &memory_stream);
 			void							load						(IReader &file_stream, LPCSTR game_name);
 			void							load						(LPCSTR spawn_name);
-			void							fill_new_spawns				(xr_vector<ALife::_SPAWN_ID> &spawns, ALife::_TIME_ID game_time, xr_vector<ALife::_SPAWN_ID> &objects);
+			void							fill_new_spawns				(xr_vector<ALife::_SPAWN_ID> &spawns, ALife::_TIME_ID game_time);
 	IC		const CALifeSpawnHeader			&header						() const;
 	IC		const SPAWN_GRAPH				&spawns						() const;
-	IC		void							assign_artefact_position	(CSE_ALifeAnomalousZone	*anomaly, CSE_ALifeDynamicObject *object) const;
+	//IC		void							assign_artefact_position	(CSE_ALifeAnomalousZone	*anomaly, CSE_ALifeDynamicObject *object) const;
 	IC		const ALife::_SPAWN_ID			&spawn_id					(const ALife::_SPAWN_STORY_ID &spawn_story_id) const;
 };
 

--- a/ogsr_engine/xrGame/alife_spawn_registry_inline.h
+++ b/ogsr_engine/xrGame/alife_spawn_registry_inline.h
@@ -13,20 +13,20 @@ IC	const CALifeSpawnHeader &CALifeSpawnRegistry::header	() const
 	return							(m_header);
 }
 
-IC	void CALifeSpawnRegistry::assign_artefact_position		(CSE_ALifeAnomalousZone	*anomaly, CSE_ALifeDynamicObject *object) const
-{
-	object->m_tGraphID				= anomaly->m_tGraphID;
-	VERIFY3							(anomaly->m_artefact_spawn_count,"Anomaly is outside of the AI-map but is used for artefact generation : ",anomaly->name_replace());
-	u32								index = anomaly->m_artefact_position_offset + anomaly->randI(anomaly->m_artefact_spawn_count);
-	object->o_Position				= m_artefact_spawn_positions[index].level_point();
-	object->m_tNodeID				= m_artefact_spawn_positions[index].level_vertex_id();
-	object->m_fDistance				= m_artefact_spawn_positions[index].distance();
-#ifdef DEBUG
-	if (psAI_Flags.test(aiALife)) {
-		Msg							("[LSS] Zone %s[%f][%f][%f] %d: generated artefact position %s[%f][%f][%f]",anomaly->name_replace(),VPUSH(anomaly->o_Position),anomaly->m_artefact_position_offset,object->name_replace(),VPUSH(object->o_Position));
-	}
-#endif
-}
+//IC	void CALifeSpawnRegistry::assign_artefact_position		(CSE_ALifeAnomalousZone	*anomaly, CSE_ALifeDynamicObject *object) const
+//{
+//	object->m_tGraphID				= anomaly->m_tGraphID;
+//	VERIFY3							(anomaly->m_artefact_spawn_count,"Anomaly is outside of the AI-map but is used for artefact generation : ",anomaly->name_replace());
+//	u32								index = anomaly->m_artefact_position_offset + anomaly->randI(anomaly->m_artefact_spawn_count);
+//	object->o_Position				= m_artefact_spawn_positions[index].level_point();
+//	object->m_tNodeID				= m_artefact_spawn_positions[index].level_vertex_id();
+//	object->m_fDistance				= m_artefact_spawn_positions[index].distance();
+//#ifdef DEBUG
+//	if (psAI_Flags.test(aiALife)) {
+//		Msg							("[LSS] Zone %s[%f][%f][%f] %d: generated artefact position %s[%f][%f][%f]",anomaly->name_replace(),VPUSH(anomaly->o_Position),anomaly->m_artefact_position_offset,object->name_replace(),VPUSH(object->o_Position));
+//	}
+//#endif
+//}
 
 IC	const CALifeSpawnRegistry::SPAWN_GRAPH &CALifeSpawnRegistry::spawns	() const
 {

--- a/ogsr_engine/xrGame/alife_surge_manager.cpp
+++ b/ogsr_engine/xrGame/alife_surge_manager.cpp
@@ -47,21 +47,9 @@ void CALifeSurgeManager::spawn_new_spawns			()
 	}
 }
 
-void CALifeSurgeManager::fill_spawned_objects		()
-{
-	m_temp_spawned_objects.clear	();
-
-	D_OBJECT_P_MAP::const_iterator	I = objects().objects().begin();
-	D_OBJECT_P_MAP::const_iterator	E = objects().objects().end();
-	for ( ; I != E; ++I)
-		if (spawns().spawns().vertex((*I).second->m_tSpawnID))
-			m_temp_spawned_objects.push_back	((*I).second->m_tSpawnID);
-}
-
 void CALifeSurgeManager::spawn_new_objects			()
 {
-	fill_spawned_objects			();
-	spawns().fill_new_spawns		(m_temp_spawns,time_manager().game_time(),m_temp_spawned_objects);
+	spawns().fill_new_spawns		(m_temp_spawns,time_manager().game_time());
 	spawn_new_spawns				();
 	VERIFY							(graph().actor());
 }

--- a/ogsr_engine/xrGame/alife_surge_manager.h
+++ b/ogsr_engine/xrGame/alife_surge_manager.h
@@ -19,10 +19,8 @@ protected:
 
 protected:
 	xr_vector<ALife::_SPAWN_ID>		m_temp_spawns;
-	xr_vector<ALife::_SPAWN_ID>		m_temp_spawned_objects;
 
 private:
-			void			fill_spawned_objects		();
 			void			spawn_new_spawns			();
 
 protected:

--- a/ogsr_engine/xrGame/level_script.cpp
+++ b/ogsr_engine/xrGame/level_script.cpp
@@ -395,6 +395,11 @@ bool is_level_present()
 	return (!!g_pGameLevel);
 }
 
+bool is_removing_objects_script()
+{
+	return Level().is_removing_objects();
+}
+
 CPHCall* add_call(const luabind::functor<bool> &condition,const luabind::functor<void> &action)
 {
 	luabind::functor<bool>		_condition = condition;
@@ -970,6 +975,7 @@ void CLevel::script_register(lua_State *L)
 	[
 		// obsolete\deprecated
 		def("object_by_id",						get_object_by_id),
+		def("is_removing_objects",				is_removing_objects_script),
 #ifdef DEBUG
 		def("debug_object",						get_object_by_name),
 		def("debug_actor",						tpfGetActor),

--- a/ogsr_engine/xrGame/ui/UITrackBar.cpp
+++ b/ogsr_engine/xrGame/ui/UITrackBar.cpp
@@ -13,10 +13,10 @@
 
 CUITrackBar::CUITrackBar()
 	: m_f_min(0),
-	  m_f_max(1),
-	  m_f_val(0),
-	  m_f_back_up(0),
-	 m_f_step(0.01f),
+	m_f_max(1),
+	m_f_val(0),
+	m_f_back_up(0),
+	m_f_step(0.01f),
 	m_b_is_float(true),
 	m_b_invert(false)
 {	
@@ -54,7 +54,6 @@ void CUITrackBar::Init(float x, float y, float width, float height){
 	float				item_width;
 	CUIWindow::Init		(x, y, width, DEF_CONTROL_HEIGHT);
 
-
 	item_height			= CUITextureMaster::GetTextureHeight(strconcat(sizeof(buf),buf,FRAME_LINE_TEXTURE,"_b"));
 	m_pFrameLine->Init	(0, (height - item_height)/2, width, item_height);
 	m_pFrameLine->InitTexture(FRAME_LINE_TEXTURE);
@@ -63,7 +62,7 @@ void CUITrackBar::Init(float x, float y, float width, float height){
 
 	strconcat			(sizeof(buf),buf,SLIDER_TEXTURE,"_e");
 	item_width			= CUITextureMaster::GetTextureWidth(buf);
-    item_height			= CUITextureMaster::GetTextureHeight(buf);
+	item_height			= CUITextureMaster::GetTextureHeight(buf);
 
 	item_width *= UI()->get_current_kx();
 
@@ -73,10 +72,26 @@ void CUITrackBar::Init(float x, float y, float width, float height){
 
 void CUITrackBar::SetCurrentValue()
 {
-	if(m_b_is_float)
-		GetOptFloatValue	(m_f_val, m_f_min, m_f_max);
+	if (m_b_is_float)
+	{
+		GetOptFloatValue(m_f_val, m_f_min, m_f_max);
+
+		if (!fis_zero(m_f_min_xml) && m_f_min_xml > m_f_min)
+			m_f_min = m_f_min_xml;
+
+		if (!fis_zero(m_f_max_xml) && m_f_max_xml < m_f_max)
+			m_f_max = m_f_max_xml;
+	}
 	else
-		GetOptIntegerValue		(m_i_val, m_i_min, m_i_max);
+	{
+		GetOptIntegerValue(m_i_val, m_i_min, m_i_max);
+
+		if (!fis_zero(m_f_min_xml) && m_f_min_xml > m_i_min)
+			m_i_min = iFloor(m_f_min_xml);
+
+		if (!fis_zero(m_f_max_xml) && m_f_max_xml < m_i_max)
+			m_i_max = iFloor(m_f_max_xml);
+	}
 
 	UpdatePos			();
 }
@@ -90,10 +105,25 @@ void CUITrackBar::Draw()
 void CUITrackBar::SaveValue()
 {
 	CUIOptionsItem::SaveValue	();
-	if(m_b_is_float)
-		SaveOptFloatValue			(m_f_val);
+
+	string128 buf;
+	if (m_b_is_float)
+	{
+		SaveOptFloatValue(m_f_val);
+		if (m_f_step >= 1)
+			sprintf_s(buf, "%2.0f", m_f_val);
+		else if (m_f_step >= 0.1)
+			sprintf_s(buf, "%3.1f", m_f_val);
+		else
+			sprintf_s(buf, "%4.2f", m_f_val);
+	}
 	else
-		SaveOptIntegerValue			(m_i_val);
+	{
+		SaveOptIntegerValue(m_i_val);
+		sprintf_s(buf, "%d", m_i_val);
+	}
+
+	m_pSlider->SetText(buf);
 }
 
 bool CUITrackBar::IsChanged()

--- a/ogsr_engine/xrGame/ui/UITrackBar.h
+++ b/ogsr_engine/xrGame/ui/UITrackBar.h
@@ -30,6 +30,9 @@ public:
 			void	SetType					(bool b_float){m_b_is_float=b_float;};
 			bool	GetCheck				();
 			void	SetCheck				(bool b);
+
+			void	SetMin					(float v) { m_f_min_xml = v; }
+			void	SetMax					(float v) { m_f_max_xml = v; }
 protected:
 			void 	UpdatePos				();
 			void 	UpdatePosRelativeToMouse();
@@ -39,6 +42,9 @@ protected:
 	CUIFrameLineWnd*	m_pFrameLine_d;
 	bool				m_b_invert;
 	bool				m_b_is_float;
+
+	float				m_f_max_xml = 0.f;
+	float				m_f_min_xml = 0.f;
 
 	union{
 		struct{

--- a/ogsr_engine/xrGame/ui/UIXmlInit.cpp
+++ b/ogsr_engine/xrGame/ui/UIXmlInit.cpp
@@ -1303,9 +1303,15 @@ bool CUIXmlInit::InitTrackBar(CUIXml& xml_doc, const char* path, int index, CUIT
 
 	int invert			= xml_doc.ReadAttribInt(path, index, "invert", 0);
 	pWnd->SetInvert		(!!invert);
+
 	float step			= xml_doc.ReadAttribFlt(path, index, "step", 0.1f);
 	pWnd->SetStep		(step);
-	
+
+	float min_xml		= xml_doc.ReadAttribFlt(path, index, "min", 0.0f);
+	pWnd->SetMin		(min_xml);
+
+	float max_xml		= xml_doc.ReadAttribFlt(path, index, "max", 0.0f);
+	pWnd->SetMax		(max_xml);
 
 	return				true;
 }


### PR DESCRIPTION
Формат файлов такой же, как выдает acdc при распаковке.
Для подключения, добавить system.ltx
```
[engine_custom_spawn]
waypoints_file = <name_of_file.ltx>
```
<name_of_file.ltx> - путь к файлу в $game_config$
При загрузке, пути из файла будут заменять пути из all.spawn с таким же именем.
Можно вообще убрать пути из своего all.spawn и все перенести в файлы, время загрузки всех путей порядка 0,2-0,3 сек из файлов.

Так же, немного выкинул мусор при создании НИ