### PR TITLE
Исправил баг с перезарядкой оружия, если в external.ltx включена авто…

### DIFF
--- a/ogsr_engine/xrGame/Weapon.cpp
+++ b/ogsr_engine/xrGame/Weapon.cpp
@@ -978,7 +978,10 @@ void CWeapon::UpdateCL		()
           auto state = idle_state();
           if ( m_idle_state != state ) {
             m_idle_state = state;
-            SwitchState( eIdle );
+			if (GetNextState() != eMagEmpty && GetNextState() != eReload)
+			{
+				SwitchState(eIdle);
+			}
           }
         }
         else

--- a/ogsr_engine/xrGame/WeaponMagazined.cpp
+++ b/ogsr_engine/xrGame/WeaponMagazined.cpp
@@ -449,7 +449,10 @@ void CWeaponMagazined::OnStateSwitch	(u32 S)
 		switch2_Empty	();
 		// Callbacks added by Cribbledirge.
 		StateSwitchCallback(GameObject::eOnActorWeaponEmpty, GameObject::eOnNPCWeaponEmpty);
-		SwitchState(eIdle);
+		if (GetNextState() != eReload)
+		{
+			SwitchState(eIdle);
+		}
 		break;
 	case eReload:
 		switch2_Reload	();


### PR DESCRIPTION
…перезарядка

Предусловие : Включить autoreload_wpn в external.ltx
Если начать стрелять и не отпустить ЛКМ когда закончились патроны в магазине, то звук перезарядки запустится, но анимация перезарядки не будет проигрываться, а застрянет в состоянии Idle. Потом если отпустить ЛКМ - уже запустится анимация и опять звук перезарядки. В результате звук перезарядки играет 2 раза.
Видео: https://www.youtube.com/watch?v=2VSssL1n4YU
Частично баг появился после этого фикса: https://github.com/OGSR/OGSR-Engine/commit/c2eed60e09b1619232cee43b6b16a687809b66f6