### PR TITLE
Оптимизация

### DIFF
--- a/Game/Resources_SoC_1.0006/gamedata/config/ui/ui_mm_opt.xml
+++ b/Game/Resources_SoC_1.0006/gamedata/config/ui/ui_mm_opt.xml
@@ -735,12 +735,6 @@
 	<frame x="0" y="0" width="470" height="330">
 		<texture>ui_tablist_textbox</texture>
 	</frame>
-	<frame_gameplay x="0" y="0" width="470" height="330">
-		<texture>ui_tablist_textbox</texture>
-	</frame_gameplay>
-	<frame_videoadv x="0" y="0" width="470" height="330">
-		<texture>ui_tablist_textbox</texture>
-	</frame_videoadv>
 	<download_static x="186" y="717" width="603" height="51">
 		<texture>ui_patch_back</texture>
 	</download_static>

--- a/Game/Resources_SoC_1.0006/gamedata/scripts/ui_mm_opt_gameplay.script
+++ b/Game/Resources_SoC_1.0006/gamedata/scripts/ui_mm_opt_gameplay.script
@@ -11,7 +11,7 @@ function opt_gameplay:InitControls(x, y, xml)
 	self:Init(x, y, 738, 416)
 	self:SetAutoDelete(true)
 
-	xml:InitFrame("frame_gameplay", self)
+	xml:InitFrame("frame", self)
 
 	xml:InitStatic("tab_gameplay:cap_difficulty", self)
 

--- a/Game/Resources_SoC_1.0006/gamedata/scripts/ui_mm_opt_video_adv.script
+++ b/Game/Resources_SoC_1.0006/gamedata/scripts/ui_mm_opt_video_adv.script
@@ -97,7 +97,7 @@ function opt_video_adv:InitControls(x, y, xml, handler)
 	self:Init(x, y, 738, 416)
 	self:SetAutoDelete(true)
 
-	xml:InitFrame("frame_videoadv", self)
+	xml:InitFrame("frame", self)
 	self.scroll_v = xml:InitScrollView("video_adv:scroll_v", self)
 
 	-- перебираем с конца, поскольку в настройках scroll view в xml стоит параметр flip_vert="1",


### PR DESCRIPTION
Вкладки "Видео"(расширенные) и "Игра" теперь используют общий frame, вместо индивидуальных "frame_videoadv" и "frame_gameplay"
Не понятно зачем именно для этих вкладок сделаны свои frame'ы