### PR TITLE
Исправление наложения кнопок

### DIFF
--- a/Game/Resources_SoC_1.0006/gamedata/config/ui/ui_mm_load_dlg.xml
+++ b/Game/Resources_SoC_1.0006/gamedata/config/ui/ui_mm_load_dlg.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<window>
+	<back_video x="0" y="0" width="1024" height="430">
+		<texture x="0" y="0" width="1024" height="430">ui\ui_mm_window_back_crop</texture>
+	</back_video>
+
+	<_back_video x="0" y="0" width="1024" height="512" stretch="1">
+		<texture>ui\ui_vid_back_04</texture>
+	</_back_video>
+
+	<background x="0" y="0" width="1024" height="768">
+		<texture x="0" y="0" width="1024" height="768">ui\ui_static_mm_back_04</texture>
+	</background>
+
+	<newspaper_video x="137" y="512" width="256" height="256">
+		<texture>ui\ui_mm_newspaper</texture>
+	</newspaper_video>
+	
+	<form x="415" y="168" width="560" height="460">
+		<_texture>ui\ui_options_menu_static</_texture>
+		<_texture_offset x="-29" y="-19"/>
+		<texture>ui_menu_options_dlg</texture>
+		
+		<caption x="65" y="10" width="500" height="25" complex_mode="0">
+			<text font="graffiti22" r="184" g="168" b="131">ui_mm_load_game</text>
+		</caption>
+		
+		<picture x="105" y="71" width="128" height="128" clipper="1">
+			<texture>ui\ui_noise</texture>
+		</picture>
+		
+		<file_info x="47" y="55" width="497" height="171">
+			<_texture>ui\ui_static_loadgameinfo</_texture>
+			<texture x="0" y="768" width="497" height="171">ui\ui_static_mm_back_04</texture>
+		</file_info>
+		
+		<file_caption x="299" y="109" width="512" height="20" complex_mode="1">
+			<text font="letterica18" r="238" g="155" b="23"/>
+		</file_caption>
+		
+		<file_data x="299" y="129" width="512" height="50" complex_mode="1">
+			<text font="letterica18" r="216" g="186" b="140"/>
+		</file_data>
+		
+		<list_frame x="65" y="221" width="449" height="200">
+			<texture>ui_tablist_textbox</texture>
+		</list_frame>
+		
+		<list x="75" y="231" width="429" height="180" item_height="18">
+			<font font="letterica16" r="216" g="186" b="140" />
+		</list>
+		
+		<btn_load x="60" y="427" width="157" height="48">
+			<texture>ui_button_main01</texture>
+			<text font="graffiti22">ui_mm_load</text>
+			<text_color>
+				<e r="227" g="199" b="178"/> <t r="180" g="153" b="155"/> <d r="106" g="95" b="91"/> <h r="0" g="0" b="0"/>
+			</text_color>
+		</btn_load>
+		
+		<btn_delete x="217" y="427" width="157" height="48">
+			<texture>ui_button_main01</texture>
+			<text font="graffiti22">ui_mm_delete</text>
+			<text_color>
+				<e r="227" g="199" b="178"/> <t r="180" g="153" b="155"/> <d r="106" g="95" b="91"/> <h r="0" g="0" b="0"/>
+			</text_color>
+		</btn_delete>
+		
+		<btn_cancel x="374" y="427" width="157" height="48">
+			<texture>ui_button_main01</texture>
+			<text font="graffiti22">ui_mm_cancel</text>
+			<text_color>
+				<e r="227" g="199" b="178"/> <t r="180" g="153" b="155"/> <d r="106" g="95" b="91"/> <h r="0" g="0" b="0"/>
+			</text_color>
+		</btn_cancel>
+	</form>
+</window>

--- a/Game/Resources_SoC_1.0006/gamedata/config/ui/ui_mm_opt.xml
+++ b/Game/Resources_SoC_1.0006/gamedata/config/ui/ui_mm_opt.xml
@@ -30,7 +30,7 @@
 				<e r="227" g="199" b="178"/> <t r="180" g="153" b="155"/> <d r="106" g="95" b="91"/> <h r="0" g="0" b="0"/>
 			</text_color>
 		</btn_accept>
-		<btn_cancel x="375" y="429" width="157" height="48">
+		<btn_cancel x="376" y="429" width="157" height="48">
 			<text font="graffiti19" align="c">ui_mm_cancel</text>
 			<texture>ui_button_main03</texture>
 			<text_color>

--- a/Game/Resources_SoC_1.0006/gamedata/config/ui/ui_mm_save_dlg.xml
+++ b/Game/Resources_SoC_1.0006/gamedata/config/ui/ui_mm_save_dlg.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<window>
+	<back_video x="0" y="0" width="1024" height="430">
+		<texture x="0" y="0" width="1024" height="430">ui\ui_mm_window_back_crop</texture>
+	</back_video>
+
+	<_back_video x="0" y="0" width="1024" height="512" stretch="1">
+		<texture>ui\ui_vid_back_02</texture>
+	</_back_video>
+	
+	<background x="0" y="0" width="1024" height="768">
+		<texture>ui\ui_static_mm_back_04</texture>
+	</background>
+
+	<newspaper_video x="137" y="512" width="256" height="256">
+		<texture>ui\ui_mm_newspaper</texture>
+	</newspaper_video>
+	
+	<form x="415" y="168" width="560" height="460">
+		<_texture>ui\ui_options_menu_static</_texture>
+		<_texture_offset x="-29" y="-19"/>
+		<texture>ui_menu_options_dlg</texture>
+		
+		<caption x="65" y="10" width="500" height="25" complex_mode="0">
+			<text font="graffiti22" r="184" g="168" b="131">ui_mm_save_game</text>
+		</caption>
+		
+		<edit x="65" y="55" width="257" height="23">
+			<texture>ui_linetext_e</texture>
+			<text font="letterica18" r="240" g="217" b="182"/>
+		</edit>
+		
+		<list_frame x="65" y="96" width="449" height="307">
+			<texture>ui_tablist_textbox</texture>
+		</list_frame>
+		
+		<list x="75" y="106" width="429" height="287" item_height="18"/>
+		
+		<btn_save x="60" y="427" width="157" height="48">
+			<texture>ui_button_main01</texture>
+			<text font="graffiti22">ui_mm_save</text>
+			<text_color>
+				<e r="227" g="199" b="178"/> <t r="180" g="153" b="155"/> <d r="106" g="95" b="91"/> <h r="0" g="0" b="0"/>
+			</text_color>
+		</btn_save>
+
+		<btn_delete x="217" y="427" width="157" height="48">
+			<texture>ui_button_main01</texture>
+			<text font="graffiti22">ui_mm_delete</text>
+			<text_color>
+				<e r="227" g="199" b="178"/> <t r="180" g="153" b="155"/> <d r="106" g="95" b="91"/> <h r="0" g="0" b="0"/>
+			</text_color>
+		</btn_delete>
+		
+		<btn_cancel x="374" y="427" width="157" height="48">
+			<texture>ui_button_main01</texture>
+			<text font="graffiti22">ui_mm_cancel</text>
+			<text_color>
+				<e r="227" g="199" b="178"/> <t r="180" g="153" b="155"/> <d r="106" g="95" b="91"/> <h r="0" g="0" b="0"/>
+			</text_color>
+		</btn_cancel>
+	</form>
+</window>


### PR DESCRIPTION
Исправление наложения(наложение размером в один логический пиксель) между краями кнопок: сохранить, загрузить, применить, отмена и удалить. 
Можно было нажать на две кнопки одновременно, что в оригинале иногда приводило к вылету, а здесь просто одна из нажатых кнопок "залипала".
P.S. Новые файлы были взяты из стим-версии