### PR TITLE
Добавил новые возможности задать story_id целей в квестах 

### DIFF
--- a/ogsr_engine/xrGame/GameTask.cpp
+++ b/ogsr_engine/xrGame/GameTask.cpp
@@ -28,7 +28,14 @@ extern STORY_PAIRS story_ids;
 
 ALife::_STORY_ID story_id( LPCSTR story_id ) {
   auto I = story_ids.find( story_id );
-  ASSERT_FMT_DBG( I != story_ids.end(), "story_id not found: %s", story_id );
+  if (I == story_ids.end()) {
+	  int sid = atoi(story_id);
+	  if (sid) {
+		return ALife::_STORY_ID(sid);
+	  } else {
+		  Msg("story_id not found: %s", story_id);
+	  }
+  }
   return ALife::_STORY_ID( (*I).second );
 }
 
@@ -139,6 +146,11 @@ void CGameTask::Load(const TASK_ID& id)
 
 		LPCSTR object_story_id			= g_gameTaskXml->Read(l_root, "object_story_id", 0, NULL);
 
+		if ((NULL == object_story_id) && (NULL != objective.map_location)) {
+			object_story_id = g_gameTaskXml->ReadAttrib(l_root, "map_location_type", 0, "story_id", NULL);
+		}
+		
+
 //*
 		LPCSTR ddd;
 		ddd								= g_gameTaskXml->Read(l_root, "map_location_hidden", 0, NULL);
@@ -156,7 +168,7 @@ void CGameTask::Load(const TASK_ID& id)
 //.
 		objective.map_hint				= g_gameTaskXml->ReadAttrib(l_root, "map_location_type", 0, "hint", NULL);
 
-		if(object_story_id){
+		if(NULL != object_story_id){
 			ALife::_STORY_ID _sid		= story_id(object_story_id);
 			objective.object_id			= storyId2GameId(_sid);
 		}

--- a/ogsr_engine/xrGame/GameTask.cpp
+++ b/ogsr_engine/xrGame/GameTask.cpp
@@ -168,7 +168,7 @@ void CGameTask::Load(const TASK_ID& id)
 //.
 		objective.map_hint				= g_gameTaskXml->ReadAttrib(l_root, "map_location_type", 0, "hint", NULL);
 
-		if(NULL != object_story_id){
+		if(object_story_id){
 			ALife::_STORY_ID _sid		= story_id(object_story_id);
 			objective.object_id			= storyId2GameId(_sid);
 		}


### PR DESCRIPTION
Теперь при создании квестов в теге `object_story_id`  можно указывать числовой story_id, а не только его строковый псевдоним. Также теперь можно вообще не писать теги  `object_story_id` для задания story_id цели, теперь можно в теге `map_location_type` задать аттрибут `story_id` приравнять его числовому story_id или псевдониму (из game_story_ids.ltx) для задания цели.
Протестировано.