### PR TITLE
Смещение худа оружия при передвижении вперёд/назад

### DIFF
--- a/ogsr_engine/xrGame/Weapon.cpp
+++ b/ogsr_engine/xrGame/Weapon.cpp
@@ -1790,7 +1790,7 @@ void CWeapon::UpdateHudAdditonal		(Fmatrix& trans)
 		m_fLR_MovingFactor += fVal;
 	}
 	else
-	{
+	{ // Двигаемся в любом другом направлении
 		if (m_fLR_MovingFactor < 0.0f)
 		{
 			m_fLR_MovingFactor += fStepPerUpd;

--- a/ogsr_engine/xrGame/Weapon.cpp
+++ b/ogsr_engine/xrGame/Weapon.cpp
@@ -45,55 +45,55 @@ extern ENGINE_API Fvector3 w_timers;
 
 CWeapon::CWeapon(LPCSTR name) : m_fLR_MovingFactor(0.f), m_strafe_offset{}
 {
-	SetState(eHidden);
-	SetNextState(eHidden);
-	m_sub_state = eSubstateReloadBegin;
-	m_idle_state = eIdle;
-	m_bTriStateReload = false;
-	SetDefaults();
+	SetState				(eHidden);
+	SetNextState			(eHidden);
+	m_sub_state				= eSubstateReloadBegin;
+	m_idle_state				= eIdle;
+	m_bTriStateReload		= false;
+	SetDefaults				();
 
-	m_Offset.identity();
-	m_StrapOffset.identity();
+	m_Offset.identity		();
+	m_StrapOffset.identity	();
 
-	iAmmoCurrent = -1;
-	m_dwAmmoCurrentCalcFrame = 0;
+	iAmmoCurrent			= -1;
+	m_dwAmmoCurrentCalcFrame= 0;
 
-	iAmmoElapsed = -1;
-	iMagazineSize = -1;
-	m_ammoType = 0;
+	iAmmoElapsed			= -1;
+	iMagazineSize			= -1;
+	m_ammoType				= 0;
 
-	eHandDependence = hdNone;
+	eHandDependence			= hdNone;
 
 	m_fZoomFactor = Core.Features.test(xrCore::Feature::ogse_wpn_zoom_system) ? 1.f : g_fov;
 
-	m_fZoomRotationFactor = 0.f;
+	m_fZoomRotationFactor	= 0.f;
 
 
-	m_pAmmo = nullptr;
+	m_pAmmo					= nullptr;
 
 
-	m_pFlameParticles2 = nullptr;
-	m_sFlameParticles2 = nullptr;
+	m_pFlameParticles2		= nullptr;
+	m_sFlameParticles2		= nullptr;
 
 
 	m_fCurrentCartirdgeDisp = 1.f;
 
-	m_strap_bone0 = nullptr;
-	m_strap_bone1 = nullptr;
-	m_StrapOffset.identity();
-	m_strapped_mode = false;
-	m_can_be_strapped = false;
-	m_ef_main_weapon_type = u32(-1);
-	m_ef_weapon_type = u32(-1);
-	m_UIScope = nullptr;
+	m_strap_bone0			= nullptr;
+	m_strap_bone1			= nullptr;
+	m_StrapOffset.identity	();
+	m_strapped_mode			= false;
+	m_can_be_strapped		= false;
+	m_ef_main_weapon_type	= u32(-1);
+	m_ef_weapon_type		= u32(-1);
+	m_UIScope				= nullptr;
 	m_set_next_ammoType_on_reload = u32(-1);
 
 	m_nearwall_last_hud_fov = psHUD_FOV_def;
 }
 
-CWeapon::~CWeapon()
+CWeapon::~CWeapon		()
 {
-	xr_delete(m_UIScope);
+	xr_delete	(m_UIScope);
 }
 
 //void CWeapon::Hit(float P, Fvector &dir,	
@@ -101,74 +101,74 @@ CWeapon::~CWeapon()
 //		    Fvector position_in_object_space, 
 //		    float impulse, 
 //		    ALife::EHitType hit_type)
-void CWeapon::Hit(SHit* pHDS)
+void CWeapon::Hit					(SHit* pHDS)
 {
-	//	inherited::Hit(P, dir, who, element, position_in_object_space,impulse,hit_type);
+//	inherited::Hit(P, dir, who, element, position_in_object_space,impulse,hit_type);
 	inherited::Hit(pHDS);
 }
 
 
 
-void CWeapon::UpdateXForm()
+void CWeapon::UpdateXForm	()
 {
-	if (Device.dwFrame != dwXF_Frame)
+	if (Device.dwFrame!=dwXF_Frame)
 	{
 		dwXF_Frame = Device.dwFrame;
 
-		if (0 == H_Parent())	return;
+		if (0==H_Parent())	return;
 
 		// Get access to entity and its visual
-		CEntityAlive* E = smart_cast<CEntityAlive*>(H_Parent());
-
-		if (!E)
+		CEntityAlive*	E		= smart_cast<CEntityAlive*>(H_Parent());
+		
+		if(!E) 
 			return;
 
-		const CInventoryOwner* parent = smart_cast<const CInventoryOwner*>(E);
+		const CInventoryOwner	*parent = smart_cast<const CInventoryOwner*>(E);
 		if (!parent || parent && parent->use_simplified_visual())
 			return;
 
 		if (parent->attached(this))
 			return;
 
-		R_ASSERT(E);
-		IKinematics* V = smart_cast<IKinematics*>	(E->Visual());
-		VERIFY(V);
+		R_ASSERT		(E);
+		IKinematics*	V		= smart_cast<IKinematics*>	(E->Visual());
+		VERIFY			(V);
 
 		// Get matrices
-		int				boneL, boneR, boneR2;
-		E->g_WeaponBones(boneL, boneR, boneR2);
+		int				boneL,boneR,boneR2;
+		E->g_WeaponBones(boneL,boneR,boneR2);
 		if ((HandDependence() == hd1Hand) || (GetState() == eReload) || (!E->g_Alive()))
 			boneL = boneR2;
 #pragma todo("TO ALL: serious performance problem")
 		// от mortan:
 		// https://www.gameru.net/forum/index.php?s=&showtopic=23443&view=findpost&p=1677678
 		V->CalculateBones_Invalidate();
-		V->CalculateBones(true); //V->CalculateBones	();
-		Fmatrix& mL = V->LL_GetTransform(u16(boneL));
-		Fmatrix& mR = V->LL_GetTransform(u16(boneR));
+		V->CalculateBones( true ); //V->CalculateBones	();
+		Fmatrix& mL			= V->LL_GetTransform(u16(boneL));
+		Fmatrix& mR			= V->LL_GetTransform(u16(boneR));
 		// Calculate
 		Fmatrix				mRes;
-		Fvector				R, D, N;
-		D.sub(mL.c, mR.c);
+		Fvector				R,D,N;
+		D.sub				(mL.c,mR.c);	
 
-		if (fis_zero(D.magnitude()))
+		if(fis_zero(D.magnitude()))
 		{
 			mRes.set(E->XFORM());
 			mRes.c.set(mR.c);
 		}
 		else
-		{
+		{		
 			D.normalize();
-			R.crossproduct(mR.j, D);
+			R.crossproduct	(mR.j,D);
 
-			N.crossproduct(D, R);
+			N.crossproduct	(D,R);			
 			N.normalize();
 
-			mRes.set(R, N, D, mR.c);
-			mRes.mulA_43(E->XFORM());
+			mRes.set		(R,N,D,mR.c);
+			mRes.mulA_43	(E->XFORM());
 		}
 
-		UpdatePosition(mRes);
+		UpdatePosition	(mRes);
 	}
 }
 
@@ -232,12 +232,12 @@ constexpr char* wpn_silencer_def_bone = "wpn_silencer";
 constexpr char* wpn_launcher_def_bone_shoc = "wpn_launcher";
 constexpr char* wpn_launcher_def_bone_cop = "wpn_grenade_launcher";
 
-void CWeapon::Load(LPCSTR section)
+void CWeapon::Load		(LPCSTR section)
 {
-	inherited::Load(section);
-	CShootingObject::Load(section);
+	inherited::Load					(section);
+	CShootingObject::Load			(section);
 
-	if (pSettings->line_exist(section, "flame_particles_2"))
+	if(pSettings->line_exist(section, "flame_particles_2"))
 		m_sFlameParticles2 = pSettings->r_string(section, "flame_particles_2");
 
 	if (!m_bForcedParticlesHudMode)
@@ -245,109 +245,109 @@ void CWeapon::Load(LPCSTR section)
 
 #ifdef DEBUG
 	{
-		Fvector				pos, ypr;
-		pos = pSettings->r_fvector3(section, "position");
-		ypr = pSettings->r_fvector3(section, "orientation");
-		ypr.mul(PI / 180.f);
+		Fvector				pos,ypr;
+		pos					= pSettings->r_fvector3		(section,"position");
+		ypr					= pSettings->r_fvector3		(section,"orientation");
+		ypr.mul				(PI/180.f);
 
-		m_Offset.setHPB(ypr.x, ypr.y, ypr.z);
-		m_Offset.translate_over(pos);
+		m_Offset.setHPB			(ypr.x,ypr.y,ypr.z);
+		m_Offset.translate_over	(pos);
 	}
 
-	m_StrapOffset = m_Offset;
-	if (pSettings->line_exist(section, "strap_position") && pSettings->line_exist(section, "strap_orientation")) {
-		Fvector				pos, ypr;
-		pos = pSettings->r_fvector3(section, "strap_position");
-		ypr = pSettings->r_fvector3(section, "strap_orientation");
-		ypr.mul(PI / 180.f);
+	m_StrapOffset			= m_Offset;
+	if (pSettings->line_exist(section,"strap_position") && pSettings->line_exist(section,"strap_orientation")) {
+		Fvector				pos,ypr;
+		pos					= pSettings->r_fvector3		(section,"strap_position");
+		ypr					= pSettings->r_fvector3		(section,"strap_orientation");
+		ypr.mul				(PI/180.f);
 
-		m_StrapOffset.setHPB(ypr.x, ypr.y, ypr.z);
-		m_StrapOffset.translate_over(pos);
+		m_StrapOffset.setHPB			(ypr.x,ypr.y,ypr.z);
+		m_StrapOffset.translate_over	(pos);
 	}
 #endif
 
 	// load ammo classes
-	m_ammoTypes.clear();
-	LPCSTR				S = pSettings->r_string(section, "ammo_class");
-	if (S && S[0])
+	m_ammoTypes.clear	(); 
+	LPCSTR				S = pSettings->r_string(section,"ammo_class");
+	if (S && S[0]) 
 	{
 		string128		_ammoItem;
-		int				count = _GetItemCount(S);
-		for (int it = 0; it < count; ++it)
+		int				count		= _GetItemCount	(S);
+		for (int it=0; it<count; ++it)	
 		{
-			_GetItem(S, it, _ammoItem);
-			m_ammoTypes.push_back(_ammoItem);
+			_GetItem				(S,it,_ammoItem);
+			m_ammoTypes.push_back	(_ammoItem);
 		}
 	}
 
-	iAmmoElapsed = pSettings->r_s32(section, "ammo_elapsed");
-	iMagazineSize = pSettings->r_s32(section, "ammo_mag_size");
-
+	iAmmoElapsed		= pSettings->r_s32		(section,"ammo_elapsed"		);
+	iMagazineSize		= pSettings->r_s32		(section,"ammo_mag_size"	);
+	
 	////////////////////////////////////////////////////
 	// дисперсия стрельбы
 
 	//подбрасывание камеры во время отдачи
-	camMaxAngle = pSettings->r_float(section, "cam_max_angle");
-	camMaxAngle = deg2rad(camMaxAngle);
-	camRelaxSpeed = pSettings->r_float(section, "cam_relax_speed");
-	camRelaxSpeed = deg2rad(camRelaxSpeed);
+	camMaxAngle			= pSettings->r_float		(section,"cam_max_angle"	); 
+	camMaxAngle			= deg2rad					(camMaxAngle);
+	camRelaxSpeed		= pSettings->r_float		(section,"cam_relax_speed"	); 
+	camRelaxSpeed		= deg2rad					(camRelaxSpeed);
 	if (pSettings->line_exist(section, "cam_relax_speed_ai"))
 	{
-		camRelaxSpeed_AI = pSettings->r_float(section, "cam_relax_speed_ai");
-		camRelaxSpeed_AI = deg2rad(camRelaxSpeed_AI);
+		camRelaxSpeed_AI		= pSettings->r_float		(section,"cam_relax_speed_ai"	); 
+		camRelaxSpeed_AI		= deg2rad					(camRelaxSpeed_AI);
 	}
 	else
 	{
-		camRelaxSpeed_AI = camRelaxSpeed;
+		camRelaxSpeed_AI	= camRelaxSpeed;
 	}
+	
+//	camDispersion		= pSettings->r_float		(section,"cam_dispersion"	); 
+//	camDispersion		= deg2rad					(camDispersion);
 
-	//	camDispersion		= pSettings->r_float		(section,"cam_dispersion"	); 
-	//	camDispersion		= deg2rad					(camDispersion);
-
-	camMaxAngleHorz = pSettings->r_float(section, "cam_max_angle_horz");
-	camMaxAngleHorz = deg2rad(camMaxAngleHorz);
-	camStepAngleHorz = pSettings->r_float(section, "cam_step_angle_horz");
-	camStepAngleHorz = deg2rad(camStepAngleHorz);
-	camDispertionFrac = READ_IF_EXISTS(pSettings, r_float, section, "cam_dispertion_frac", 0.7f);
+	camMaxAngleHorz		= pSettings->r_float		(section,"cam_max_angle_horz"	); 
+	camMaxAngleHorz		= deg2rad					(camMaxAngleHorz);
+	camStepAngleHorz	= pSettings->r_float		(section,"cam_step_angle_horz"	); 
+	camStepAngleHorz	= deg2rad					(camStepAngleHorz);	
+	camDispertionFrac			= READ_IF_EXISTS(pSettings, r_float, section, "cam_dispertion_frac",	0.7f);
 	//  [8/2/2005]
 	//m_fParentDispersionModifier = READ_IF_EXISTS(pSettings, r_float, section, "parent_dispersion_modifier",1.0f);
-	m_fPDM_disp_base = READ_IF_EXISTS(pSettings, r_float, section, "PDM_disp_base", 1.0f);
-	m_fPDM_disp_vel_factor = READ_IF_EXISTS(pSettings, r_float, section, "PDM_disp_vel_factor", 1.0f);
-	m_fPDM_disp_accel_factor = READ_IF_EXISTS(pSettings, r_float, section, "PDM_disp_accel_factor", 1.0f);
-	m_fPDM_disp_crouch = READ_IF_EXISTS(pSettings, r_float, section, "PDM_disp_crouch", 1.0f);
-	m_fPDM_disp_crouch_no_acc = READ_IF_EXISTS(pSettings, r_float, section, "PDM_disp_crouch_no_acc", 1.0f);
+	m_fPDM_disp_base			= READ_IF_EXISTS(pSettings, r_float, section, "PDM_disp_base",	1.0f);
+	m_fPDM_disp_vel_factor		= READ_IF_EXISTS(pSettings, r_float, section, "PDM_disp_vel_factor",	1.0f);
+	m_fPDM_disp_accel_factor	= READ_IF_EXISTS(pSettings, r_float, section, "PDM_disp_accel_factor",	1.0f);
+	m_fPDM_disp_crouch			= READ_IF_EXISTS(pSettings, r_float, section, "PDM_disp_crouch",	1.0f);
+	m_fPDM_disp_crouch_no_acc	= READ_IF_EXISTS(pSettings, r_float, section, "PDM_disp_crouch_no_acc",	1.0f);
 	//  [8/2/2005]
 
-	fireDispersionConditionFactor = pSettings->r_float(section, "fire_dispersion_condition_factor");
-	misfireProbability = pSettings->r_float(section, "misfire_probability");
-	misfireConditionK = READ_IF_EXISTS(pSettings, r_float, section, "misfire_condition_k", 1.0f);
-	conditionDecreasePerShot = pSettings->r_float(section, "condition_shot_dec");
-	conditionDecreasePerShotOnHit = READ_IF_EXISTS(pSettings, r_float, section, "condition_shot_dec_on_hit", 0.f);
-	conditionDecreasePerShotSilencer = READ_IF_EXISTS(pSettings, r_float, section, "condition_shot_dec_silencer", conditionDecreasePerShot);
-
-	vLoadedFirePoint = pSettings->r_fvector3(section, "fire_point");
-
-	if (pSettings->line_exist(section, "fire_point2"))
-		vLoadedFirePoint2 = pSettings->r_fvector3(section, "fire_point2");
-	else
-		vLoadedFirePoint2 = vLoadedFirePoint;
+	fireDispersionConditionFactor = pSettings->r_float(section,"fire_dispersion_condition_factor"); 
+	misfireProbability			  = pSettings->r_float(section,"misfire_probability"); 
+	misfireConditionK			  = READ_IF_EXISTS(pSettings, r_float, section, "misfire_condition_k",	1.0f);
+	conditionDecreasePerShot	  = pSettings->r_float(section,"condition_shot_dec"); 
+	conditionDecreasePerShotOnHit = READ_IF_EXISTS( pSettings, r_float, section, "condition_shot_dec_on_hit", 0.f );
+	conditionDecreasePerShotSilencer = READ_IF_EXISTS( pSettings, r_float, section, "condition_shot_dec_silencer", conditionDecreasePerShot );
+		
+	vLoadedFirePoint	= pSettings->r_fvector3		(section,"fire_point"		);
+	
+	if(pSettings->line_exist(section,"fire_point2")) 
+		vLoadedFirePoint2= pSettings->r_fvector3	(section,"fire_point2");
+	else 
+		vLoadedFirePoint2= vLoadedFirePoint;
 
 	// hands
-	eHandDependence = EHandDependence(pSettings->r_s32(section, "hand_dependence"));
-	m_bIsSingleHanded = true;
+	eHandDependence		= EHandDependence(pSettings->r_s32(section,"hand_dependence"));
+	m_bIsSingleHanded	= true;
 	if (pSettings->line_exist(section, "single_handed"))
-		m_bIsSingleHanded = !!pSettings->r_bool(section, "single_handed");
+		m_bIsSingleHanded	= !!pSettings->r_bool(section, "single_handed");
 	// 
-	m_fMinRadius = pSettings->r_float(section, "min_radius");
-	m_fMaxRadius = pSettings->r_float(section, "max_radius");
+	m_fMinRadius		= pSettings->r_float		(section,"min_radius");
+	m_fMaxRadius		= pSettings->r_float		(section,"max_radius");
 
 
 	// информация о возможных апгрейдах и их визуализации в инвентаре
-	m_eScopeStatus = (ALife::EWeaponAddonStatus)pSettings->r_s32(section, "scope_status");
-	m_eSilencerStatus = (ALife::EWeaponAddonStatus)pSettings->r_s32(section, "silencer_status");
-	m_eGrenadeLauncherStatus = (ALife::EWeaponAddonStatus)pSettings->r_s32(section, "grenade_launcher_status");
+	m_eScopeStatus			 = (ALife::EWeaponAddonStatus)pSettings->r_s32(section,"scope_status");
+	m_eSilencerStatus		 = (ALife::EWeaponAddonStatus)pSettings->r_s32(section,"silencer_status");
+	m_eGrenadeLauncherStatus = (ALife::EWeaponAddonStatus)pSettings->r_s32(section,"grenade_launcher_status");
 
-	m_bZoomEnabled = !!pSettings->r_bool(section, "zoom_enabled");
+	m_bZoomEnabled = !!pSettings->r_bool(section,"zoom_enabled");
 	m_bUseScopeZoom = !!READ_IF_EXISTS(pSettings, r_bool, section, "use_scope_zoom", false);
 	m_bUseScopeGrenadeZoom = !!READ_IF_EXISTS(pSettings, r_bool, section, "use_scope_grenade_zoom", false);
 	m_bUseScopeDOF = !!READ_IF_EXISTS(pSettings, r_bool, section, "use_scope_dof", true);
@@ -363,46 +363,46 @@ void CWeapon::Load(LPCSTR section)
 
 	m_fZoomFactor = CurrentZoomFactor();
 
-	m_allScopeNames.clear();
+        m_allScopeNames.clear();
 	m_highlightAddons.clear();
-	if (m_eScopeStatus == ALife::eAddonAttachable)
+	if(m_eScopeStatus == ALife::eAddonAttachable)
 	{
-		m_sScopeName = pSettings->r_string(section, "scope_name");
-		m_iScopeX = pSettings->r_s32(section, "scope_x");
-		m_iScopeY = pSettings->r_s32(section, "scope_y");
+		m_sScopeName = pSettings->r_string(section,"scope_name");
+		m_iScopeX = pSettings->r_s32(section,"scope_x");
+		m_iScopeY = pSettings->r_s32(section,"scope_y");
 
-		m_allScopeNames.push_back(m_sScopeName);
-		if (pSettings->line_exist(section, "scope_names")) {
-			LPCSTR S = pSettings->r_string(section, "scope_names");
-			if (S && S[0]) {
-				string128 _scopeItem;
-				int count = _GetItemCount(S);
-				for (int it = 0; it < count; ++it) {
-					_GetItem(S, it, _scopeItem);
-					m_allScopeNames.push_back(_scopeItem);
-					m_highlightAddons.push_back(_scopeItem);
-				}
-			}
-		}
+                m_allScopeNames.push_back( m_sScopeName );
+                if ( pSettings->line_exist( section, "scope_names" ) ) {
+                  LPCSTR S = pSettings->r_string( section, "scope_names" );
+                  if ( S && S[ 0 ] ) {
+                    string128 _scopeItem;
+                    int count = _GetItemCount( S );
+                    for ( int it = 0; it < count; ++it ) {
+                      _GetItem( S, it, _scopeItem );
+                      m_allScopeNames.push_back( _scopeItem );
+                      m_highlightAddons.push_back( _scopeItem );
+                    }
+                  }
+                }
 	}
 
-	if (m_eSilencerStatus == ALife::eAddonAttachable)
+	if(m_eSilencerStatus == ALife::eAddonAttachable)
 	{
-		m_sSilencerName = pSettings->r_string(section, "silencer_name");
-		m_iSilencerX = pSettings->r_s32(section, "silencer_x");
-		m_iSilencerY = pSettings->r_s32(section, "silencer_y");
+		m_sSilencerName = pSettings->r_string(section,"silencer_name");
+		m_iSilencerX = pSettings->r_s32(section,"silencer_x");
+		m_iSilencerY = pSettings->r_s32(section,"silencer_y");
 	}
 
-	if (m_eGrenadeLauncherStatus == ALife::eAddonAttachable)
+	if(m_eGrenadeLauncherStatus == ALife::eAddonAttachable)
 	{
-		m_sGrenadeLauncherName = pSettings->r_string(section, "grenade_launcher_name");
-		m_iGrenadeLauncherX = pSettings->r_s32(section, "grenade_launcher_x");
-		m_iGrenadeLauncherY = pSettings->r_s32(section, "grenade_launcher_y");
+		m_sGrenadeLauncherName = pSettings->r_string(section,"grenade_launcher_name");
+		m_iGrenadeLauncherX = pSettings->r_s32(section,"grenade_launcher_x");
+		m_iGrenadeLauncherY = pSettings->r_s32(section,"grenade_launcher_y");
 	}
 
 
 	// Кости мировой модели оружия
-	m_sWpn_scope_bone = READ_IF_EXISTS(pSettings, r_string, section, "scope_bone", wpn_scope_def_bone);
+	m_sWpn_scope_bone    = READ_IF_EXISTS(pSettings, r_string, section, "scope_bone", wpn_scope_def_bone);
 	m_sWpn_silencer_bone = READ_IF_EXISTS(pSettings, r_string, section, "silencer_bone", wpn_silencer_def_bone);
 	m_sWpn_launcher_bone = READ_IF_EXISTS(pSettings, r_string, section, "launcher_bone", wpn_launcher_def_bone_shoc);
 
@@ -422,7 +422,7 @@ void CWeapon::Load(LPCSTR section)
 	}
 
 	// Кости худовой модели оружия - если не прописаны, используются имена из конфига мировой модели.
-	m_sHud_wpn_scope_bone = READ_IF_EXISTS(pSettings, r_string, hud_sect, "scope_bone", m_sWpn_scope_bone);
+	m_sHud_wpn_scope_bone    = READ_IF_EXISTS(pSettings, r_string, hud_sect, "scope_bone", m_sWpn_scope_bone);
 	m_sHud_wpn_silencer_bone = READ_IF_EXISTS(pSettings, r_string, hud_sect, "silencer_bone", m_sWpn_silencer_bone);
 	m_sHud_wpn_launcher_bone = READ_IF_EXISTS(pSettings, r_string, hud_sect, "launcher_bone", m_sWpn_launcher_bone);
 
@@ -453,7 +453,7 @@ void CWeapon::Load(LPCSTR section)
 	InitAddons();
 
 	m_bHideCrosshairInZoom = true;
-	if (pSettings->line_exist(hud_sect, "zoom_hide_crosshair"))
+	if(pSettings->line_exist(hud_sect, "zoom_hide_crosshair"))
 		m_bHideCrosshairInZoom = !!pSettings->r_bool(hud_sect, "zoom_hide_crosshair");
 
 	m_bZoomInertionAllow = READ_IF_EXISTS(pSettings, r_bool, hud_sect, "allow_zoom_inertion", READ_IF_EXISTS(pSettings, r_bool, "features", "default_allow_zoom_inertion", true));
@@ -465,11 +465,11 @@ void CWeapon::Load(LPCSTR section)
 	m_u8TracerColorID = READ_IF_EXISTS(pSettings, r_u8, section, "tracers_color_ID", u8(-1));
 
 	string256						temp;
-	for (int i = egdNovice; i < egdCount; ++i) {
-		strconcat(sizeof(temp), temp, "hit_probability_", get_token_name(difficulty_type_token, i));
-		m_hit_probability[i] = READ_IF_EXISTS(pSettings, r_float, section, temp, 1.f);
+	for (int i=egdNovice; i<egdCount; ++i) {
+		strconcat					(sizeof(temp),temp,"hit_probability_",get_token_name(difficulty_type_token,i));
+		m_hit_probability[i]		= READ_IF_EXISTS(pSettings,r_float,section,temp,1.f);
 	}
-
+	
 	if (pSettings->line_exist(section, "highlight_addons")) {
 		LPCSTR S = pSettings->r_string(section, "highlight_addons");
 		if (S && S[0]) {
@@ -517,10 +517,10 @@ void CWeapon::Load(LPCSTR section)
 	m_longitudinal_offset[1] = READ_IF_EXISTS(pSettings, r_float, section, xr_strconcat(val_name, "longitudinal_hud_offset_aim", _prefix), m_longitudinal_offset[0]);
 
 	// Параметры стрейфа
-	float fFullStrafeTime = READ_IF_EXISTS(pSettings, r_float, section, "strafe_transition_time", 0.25f);
+	float fFullStrafeTime     = READ_IF_EXISTS(pSettings, r_float, section, "strafe_transition_time", 0.25f);
 	float fFullStrafeTime_aim = READ_IF_EXISTS(pSettings, r_float, section, "strafe_aim_transition_time", 0.15f);
-	bool bStrafeEnabled = READ_IF_EXISTS(pSettings, r_bool, section, "strafe_enabled", READ_IF_EXISTS(pSettings, r_bool, "features", "default_strafe_enabled", true));
-	bool bStrafeEnabled_aim = READ_IF_EXISTS(pSettings, r_bool, section, "strafe_aim_enabled", false);
+	bool bStrafeEnabled       = READ_IF_EXISTS(pSettings, r_bool, section, "strafe_enabled", READ_IF_EXISTS(pSettings, r_bool, "features", "default_strafe_enabled", true));
+	bool bStrafeEnabled_aim   = READ_IF_EXISTS(pSettings, r_bool, section, "strafe_aim_enabled", false);
 
 	// Параметры движения вперёд/назад
 	float fFullLongitudinalTime = READ_IF_EXISTS(pSettings, r_float, section, "longitudinal_transition_time", 0.18f);
@@ -540,15 +540,15 @@ void CWeapon::Load(LPCSTR section)
 	////////////////////////////////////////////
 }
 
-void CWeapon::LoadFireParams(LPCSTR section, LPCSTR prefix)
+void CWeapon::LoadFireParams		(LPCSTR section, LPCSTR prefix)
 {
-	camDispersion = pSettings->r_float(section, "cam_dispersion");
-	camDispersion = deg2rad(camDispersion);
+	camDispersion		= pSettings->r_float		(section,"cam_dispersion"	); 
+	camDispersion		= deg2rad					(camDispersion);
 
-	if (pSettings->line_exist(section, "cam_dispersion_inc"))
+	if (pSettings->line_exist(section,"cam_dispersion_inc"))
 	{
-		camDispersionInc = pSettings->r_float(section, "cam_dispersion_inc");
-		camDispersionInc = deg2rad(camDispersionInc);
+		camDispersionInc		= pSettings->r_float		(section,"cam_dispersion_inc"	); 
+		camDispersionInc		= deg2rad					(camDispersionInc);
 	}
 	else
 		camDispersionInc = 0;
@@ -556,46 +556,46 @@ void CWeapon::LoadFireParams(LPCSTR section, LPCSTR prefix)
 	CShootingObject::LoadFireParams(section, prefix);
 }
 
-BOOL CWeapon::net_Spawn(CSE_Abstract* DC)
+BOOL CWeapon::net_Spawn		(CSE_Abstract* DC)
 {
-	BOOL bResult = inherited::net_Spawn(DC);
-	CSE_Abstract* e = (CSE_Abstract*)(DC);
-	CSE_ALifeItemWeapon* E = smart_cast<CSE_ALifeItemWeapon*>(e);
+	BOOL bResult					= inherited::net_Spawn(DC);
+	CSE_Abstract					*e	= (CSE_Abstract*)(DC);
+	CSE_ALifeItemWeapon			    *E	= smart_cast<CSE_ALifeItemWeapon*>(e);
 
 	//iAmmoCurrent					= E->a_current;
-	iAmmoElapsed = E->a_elapsed;
-	m_flagsAddOnState = E->m_addon_flags.get();
-	m_ammoType = E->ammo_type;
-	SetState(E->wpn_state);
-	SetNextState(E->wpn_state);
+	iAmmoElapsed					= E->a_elapsed;
+	m_flagsAddOnState				= E->m_addon_flags.get();
+	m_ammoType						= E->ammo_type;
+	SetState						(E->wpn_state);
+	SetNextState					(E->wpn_state);
 
-	if (m_ammoType >= m_ammoTypes.size()) {
-		Msg("! [%s]: %s: wrong m_ammoType[%u/%u]", __FUNCTION__, cName().c_str(), m_ammoType, m_ammoTypes.size() - 1);
-		m_ammoType = 0;
-		auto se_obj = alife_object();
-		if (se_obj) {
-			auto W = smart_cast<CSE_ALifeItemWeapon*>(se_obj);
-			W->ammo_type = m_ammoType;
-		}
+	if ( m_ammoType >= m_ammoTypes.size() ) {
+	  Msg( "! [%s]: %s: wrong m_ammoType[%u/%u]", __FUNCTION__, cName().c_str(), m_ammoType, m_ammoTypes.size() - 1 );
+	  m_ammoType = 0;
+	  auto se_obj = alife_object();
+	  if ( se_obj ) {
+	    auto W = smart_cast<CSE_ALifeItemWeapon*>( se_obj );
+	    W->ammo_type = m_ammoType;
+	  }
 	}
 
-	m_DefaultCartridge.Load(*m_ammoTypes[m_ammoType], u8(m_ammoType));
-	if (iAmmoElapsed)
+	m_DefaultCartridge.Load(*m_ammoTypes[m_ammoType], u8(m_ammoType));	
+	if(iAmmoElapsed) 
 	{
 		// нож автоматически заряжается двумя патронами, хотя
 		// размер магазина у него 0. Что бы зря не ругаться, проверим
 		// что в конфиге размер магазина не нулевой.
-		if (iMagazineSize && iAmmoElapsed > iMagazineSize) {
-			Msg("! [%s]: %s: wrong iAmmoElapsed[%u/%u]", __FUNCTION__, cName().c_str(), iAmmoElapsed, iMagazineSize);
-			iAmmoElapsed = iMagazineSize;
-			auto se_obj = alife_object();
-			if (se_obj) {
-				auto W = smart_cast<CSE_ALifeItemWeapon*>(se_obj);
-				W->a_elapsed = iAmmoElapsed;
-			}
+		if ( iMagazineSize && iAmmoElapsed > iMagazineSize ) {
+		  Msg( "! [%s]: %s: wrong iAmmoElapsed[%u/%u]", __FUNCTION__, cName().c_str(), iAmmoElapsed, iMagazineSize );
+		  iAmmoElapsed = iMagazineSize;
+		  auto se_obj = alife_object();
+		  if ( se_obj ) {
+		    auto W = smart_cast<CSE_ALifeItemWeapon*>( se_obj );
+		    W->a_elapsed = iAmmoElapsed;
+		  }
 		}
 		m_fCurrentCartirdgeDisp = m_DefaultCartridge.m_kDisp;
-		for (int i = 0; i < iAmmoElapsed; ++i)
+		for(int i = 0; i < iAmmoElapsed; ++i) 
 			m_magazine.push_back(m_DefaultCartridge);
 	}
 
@@ -608,221 +608,221 @@ BOOL CWeapon::net_Spawn(CSE_Abstract* DC)
 	return bResult;
 }
 
-void CWeapon::net_Destroy()
+void CWeapon::net_Destroy	()
 {
-	inherited::net_Destroy();
+	inherited::net_Destroy	();
 
 	//удалить объекты партиклов
-	StopFlameParticles();
-	StopFlameParticles2();
-	StopLight();
-	Light_Destroy();
+	StopFlameParticles	();
+	StopFlameParticles2	();
+	StopLight			();
+	Light_Destroy		();
 
 	m_magazine.clear();
 	m_magazine.shrink_to_fit();
 }
 
 BOOL CWeapon::IsUpdating()
-{
-	bool bIsActiveItem = m_pCurrentInventory && m_pCurrentInventory->ActiveItem() == this;
+{	
+	bool bIsActiveItem = m_pCurrentInventory && m_pCurrentInventory->ActiveItem()==this;
 	return bIsActiveItem || bWorking || IsPending() || getVisible();
 }
 
 void CWeapon::net_Export(NET_Packet& P)
 {
-	inherited::net_Export(P);
+	inherited::net_Export	(P);
 
-	P.w_float_q8(m_fCondition, 0.0f, 1.0f);
+	P.w_float_q8			(m_fCondition,0.0f,1.0f);
 
-	u8 need_upd = IsUpdating() ? 1 : 0;
-	P.w_u8(need_upd);
-	P.w_u16(u16(iAmmoElapsed));
-	P.w_u8(m_flagsAddOnState);
-	P.w_u8((u8)m_ammoType);
-	P.w_u8((u8)GetState());
-	P.w_u8((u8)m_bZoomMode);
+	u8 need_upd				= IsUpdating() ? 1 : 0;
+	P.w_u8					(need_upd);
+	P.w_u16					(u16(iAmmoElapsed));
+	P.w_u8					(m_flagsAddOnState);
+	P.w_u8					((u8)m_ammoType);
+	P.w_u8					((u8)GetState());
+	P.w_u8					((u8)m_bZoomMode);
 }
 
 void CWeapon::net_Import(NET_Packet& P)
 {
-	inherited::net_Import(P);
+	inherited::net_Import (P);
 
-	P.r_float_q8(m_fCondition, 0.0f, 1.0f);
+	P.r_float_q8			(m_fCondition,0.0f,1.0f);
 
-	u8 flags = 0;
-	P.r_u8(flags);
+	u8 flags				= 0;
+	P.r_u8					(flags);
 
 	u16 ammo_elapsed = 0;
-	P.r_u16(ammo_elapsed);
+	P.r_u16					(ammo_elapsed);
 
 	u8						NewAddonState;
-	P.r_u8(NewAddonState);
+	P.r_u8					(NewAddonState);
 
-	m_flagsAddOnState = NewAddonState;
-	UpdateAddonsVisibility();
+	m_flagsAddOnState		= NewAddonState;
+	UpdateAddonsVisibility	();
 
 	u8 ammoType, wstate;
-	P.r_u8(ammoType);
-	P.r_u8(wstate);
+	P.r_u8					(ammoType);
+	P.r_u8					(wstate);
 
 	u8 Zoom;
-	P.r_u8(Zoom);
+	P.r_u8					(Zoom);
 
 	if (H_Parent() && H_Parent()->Remote())
 	{
-		if (Zoom)
+		if (Zoom) 
 			OnZoomIn();
-		else
+		else 
 			OnZoomOut();
 	};
 	switch (wstate)
-	{
+	{	
 	case eFire:
 	case eFire2:
 	case eSwitch:
 	case eReload:
-	{
-	}break;
-	default:
-	{
-		if (ammoType >= m_ammoTypes.size())
-			Msg("!! Weapon [%d], State - [%d]", ID(), wstate);
-		else
 		{
-			m_ammoType = ammoType;
-			SetAmmoElapsed((ammo_elapsed));
-		}
-	}break;
+		}break;	
+	default:
+		{
+			if (ammoType >= m_ammoTypes.size())
+				Msg("!! Weapon [%d], State - [%d]", ID(), wstate);
+			else
+			{
+				m_ammoType = ammoType;
+				SetAmmoElapsed((ammo_elapsed));
+			}
+		}break;
 	}
-
+	
 	VERIFY((u32)iAmmoElapsed == m_magazine.size());
 }
 
-void CWeapon::save(NET_Packet& output_packet)
+void CWeapon::save(NET_Packet &output_packet)
 {
-	inherited::save(output_packet);
-	save_data(iAmmoElapsed, output_packet);
-	save_data(m_flagsAddOnState, output_packet);
-	save_data(m_ammoType, output_packet);
-	save_data(m_bZoomMode, output_packet);
+	inherited::save	(output_packet);
+	save_data		(iAmmoElapsed,		output_packet);
+	save_data		(m_flagsAddOnState, output_packet);
+	save_data		(m_ammoType,		output_packet);
+	save_data		(m_bZoomMode,		output_packet);
 }
 
-void CWeapon::load(IReader& input_packet)
+void CWeapon::load(IReader &input_packet)
 {
-	inherited::load(input_packet);
-	load_data(iAmmoElapsed, input_packet);
-	load_data(m_flagsAddOnState, input_packet);
-	UpdateAddonsVisibility();
-	load_data(m_ammoType, input_packet);
-	load_data(m_bZoomMode, input_packet);
+	inherited::load	(input_packet);
+	load_data		(iAmmoElapsed,		input_packet);
+	load_data		(m_flagsAddOnState, input_packet);
+	UpdateAddonsVisibility	();
+	load_data		(m_ammoType,		input_packet);
+	load_data		(m_bZoomMode,		input_packet);
 
 	if (m_bZoomMode)	OnZoomIn();
-	else			OnZoomOut();
+		else			OnZoomOut();
 }
 
 
-void CWeapon::OnEvent(NET_Packet& P, u16 type)
+void CWeapon::OnEvent(NET_Packet& P, u16 type) 
 {
 	switch (type)
 	{
 	case GE_ADDON_CHANGE:
-	{
-		P.r_u8(m_flagsAddOnState);
-		InitAddons();
-		UpdateAddonsVisibility();
-	}break;
+		{
+			P.r_u8					(m_flagsAddOnState);
+			InitAddons();
+			UpdateAddonsVisibility();
+		}break;
 
 	case GE_WPN_STATE_CHANGE:
-	{
-		u8				state;
-		P.r_u8(state);
-		P.r_u8(m_sub_state);
-		//			u8 NewAmmoType = 
-		P.r_u8();
-		u8 AmmoElapsed = P.r_u8();
-		u8 NextAmmo = P.r_u8();
-		if (NextAmmo == u8(-1))
-			m_set_next_ammoType_on_reload = u32(-1);
-		else
-			m_set_next_ammoType_on_reload = u8(NextAmmo);
+		{
+			u8				state;
+			P.r_u8			(state);
+			P.r_u8			(m_sub_state);		
+//			u8 NewAmmoType = 
+				P.r_u8();
+			u8 AmmoElapsed = P.r_u8();
+			u8 NextAmmo = P.r_u8();
+			if (NextAmmo == u8(-1))
+				m_set_next_ammoType_on_reload = u32(-1);
+			else
+				m_set_next_ammoType_on_reload = u8(NextAmmo);
 
-		if (OnClient())
-			SetAmmoElapsed(int(AmmoElapsed));
-		OnStateSwitch(u32(state), GetState());
-	}
-	break;
+			if (OnClient())
+				SetAmmoElapsed(int(AmmoElapsed));			
+			OnStateSwitch(u32(state), GetState());
+		}
+		break;
 	default:
-	{
-		inherited::OnEvent(P, type);
-	}break;
+		{
+			inherited::OnEvent(P,type);
+		}break;
 	}
 };
 
-void CWeapon::shedule_Update(u32 dT)
+void CWeapon::shedule_Update	(u32 dT)
 {
 	// Queue shrink
 //	u32	dwTimeCL		= Level().timeServer()-NET_Latency;
 //	while ((NET.size()>2) && (NET[1].dwTimeStamp<dwTimeCL)) NET.pop_front();	
 
 	// Inherited
-	inherited::shedule_Update(dT);
+	inherited::shedule_Update	(dT);
 }
 
-void CWeapon::OnH_B_Independent(bool just_before_destroy)
+void CWeapon::OnH_B_Independent	(bool just_before_destroy)
 {
-	RemoveShotEffector();
+	RemoveShotEffector			();
 
 	inherited::OnH_B_Independent(just_before_destroy);
 
 	//завершить принудительно все процессы что шли
-	FireEnd();
-	SetPending(FALSE);
-	SwitchState(eIdle);
+	FireEnd						();
+	SetPending					(FALSE);
+	SwitchState					(eIdle);
 
-	m_strapped_mode = false;
-	OnZoomOut();
-	m_fZoomRotationFactor = 0.f;
-	UpdateXForm();
+	m_strapped_mode				= false;
+	OnZoomOut					();
+	m_fZoomRotationFactor	= 0.f;
+	UpdateXForm					();
 
 	m_nearwall_last_hud_fov = psHUD_FOV_def;
 }
 
-void CWeapon::OnH_A_Independent()
+void CWeapon::OnH_A_Independent	()
 {
 	inherited::OnH_A_Independent();
-	Light_Destroy();
+	Light_Destroy				();
 };
 
-void CWeapon::OnH_A_Chield()
+void CWeapon::OnH_A_Chield		()
 {
-	inherited::OnH_A_Chield();
+	inherited::OnH_A_Chield		();
 
-	UpdateAddonsVisibility();
+	UpdateAddonsVisibility		();
 };
 
-void CWeapon::OnActiveItem()
+void CWeapon::OnActiveItem ()
 {
-	inherited::OnActiveItem();
+	inherited::OnActiveItem		();
 	//если мы занружаемся и оружие было в руках
-	SetState(eIdle);
-	SetNextState(eIdle);
+	SetState					(eIdle);
+	SetNextState				(eIdle);
 }
 
-void CWeapon::OnHiddenItem()
+void CWeapon::OnHiddenItem ()
 {
 	inherited::OnHiddenItem();
-	SetState(eHidden);
-	SetNextState(eHidden);
-	m_set_next_ammoType_on_reload = u32(-1);
+	SetState					(eHidden);
+	SetNextState				(eHidden);
+	m_set_next_ammoType_on_reload	= u32(-1);
 }
 
 
-void CWeapon::OnH_B_Chield()
+void CWeapon::OnH_B_Chield		()
 {
-	inherited::OnH_B_Chield();
+	inherited::OnH_B_Chield		();
 
-	OnZoomOut();
-	m_set_next_ammoType_on_reload = u32(-1);
+	OnZoomOut					();
+	m_set_next_ammoType_on_reload	= u32(-1);
 
 	m_nearwall_last_hud_fov = psHUD_FOV_def;
 }
@@ -863,7 +863,7 @@ void CWeapon::UpdateWeaponParams()
 			if (w_timers.z > EPS)		// оружие все еще нагрето
 			{
 				float tm = state_time_heat + previous_heating - Device.fTimeGlobal;
-				w_timers.z = (tm < EPS) ? 0.f : tm;
+				w_timers.z = (tm<EPS) ? 0.f : tm;
 			}
 		}
 		w_timers.x = Device.fTimeGlobal - state_time;		// обновляем таймер текущего состояния
@@ -886,182 +886,181 @@ u8 CWeapon::idle_state() {
 }
 
 
-void CWeapon::UpdateCL()
+void CWeapon::UpdateCL		()
 {
-	inherited::UpdateCL();
+	inherited::UpdateCL		();
 
 	UpdateHUDAddonsVisibility();
 
 	//подсветка от выстрела
-	UpdateLight();
+	UpdateLight				();
 
 	if (ParentIsActor())
 		UpdateWeaponParams();	// параметры для рендера оружия в режиме тепловидения
 
 	//нарисовать партиклы
-	UpdateFlameParticles();
-	UpdateFlameParticles2();
-
+	UpdateFlameParticles	();
+	UpdateFlameParticles2	();
+	
 	VERIFY(smart_cast<IKinematics*>(Visual()));
 
-	if (GetState() == eIdle) {
-		auto state = idle_state();
-		if (m_idle_state != state) {
-			m_idle_state = state;
+        if ( GetState() == eIdle ) {
+          auto state = idle_state();
+          if ( m_idle_state != state ) {
+            m_idle_state = state;
 			if (GetNextState() != eMagEmpty && GetNextState() != eReload)
 			{
 				SwitchState(eIdle);
 			}
-		}
-	}
-	else
-		m_idle_state = eIdle;
+          }
+        }
+        else
+          m_idle_state = eIdle;
 }
 
 
-void CWeapon::renderable_Render()
+void CWeapon::renderable_Render		()
 {
-	UpdateXForm();
+	UpdateXForm				();
 
 	//нарисовать подсветку
-	RenderLight();
+	RenderLight				();	
 
 	//если мы в режиме снайперки, то сам HUD рисовать не надо
-	if (IsZoomed() && !IsRotatingToZoom() && ZoomTexture())
+	if(IsZoomed() && !IsRotatingToZoom() && ZoomTexture())
 		RenderHud(FALSE);
 	else
 		RenderHud(TRUE);
 
-	inherited::renderable_Render();
+	inherited::renderable_Render		();
 }
 
-bool CWeapon::need_renderable()
+bool CWeapon::need_renderable() 
 {
 	return !Device.m_SecondViewport.IsSVPFrame() && !(IsZoomed() && ZoomTexture() && !IsRotatingToZoom());
 }
 
 bool CWeapon::MovingAnimAllowedNow()
-{
-	return !IsZoomed();
+{ 
+	return !IsZoomed(); 
 }
 
 void CWeapon::signal_HideComplete()
 {
-	if (H_Parent())
+	if(H_Parent())
 		setVisible(FALSE);
 	SetPending(FALSE);
 }
 
 void CWeapon::SetDefaults()
 {
-	bWorking2 = false;
-	SetPending(FALSE);
+	bWorking2			= false;
+	SetPending			(FALSE);
 
-	m_flags.set(FUsingCondition, TRUE);
-	bMisfire = false;
-	m_flagsAddOnState = 0;
-	m_bZoomMode = false;
+	m_flags.set			(FUsingCondition, TRUE);
+	bMisfire			= false;
+	m_flagsAddOnState	= 0;
+	m_bZoomMode			= false;
 }
 
 void CWeapon::UpdatePosition(const Fmatrix& trans)
 {
-	Position().set(trans.c);
-	XFORM().mul(trans, m_strapped_mode ? m_StrapOffset : m_Offset);
-	VERIFY(!fis_zero(DET(renderable.xform)));
+	Position().set		(trans.c);
+	XFORM().mul			(trans,m_strapped_mode ? m_StrapOffset : m_Offset);
+	VERIFY				(!fis_zero(DET(renderable.xform)));
 }
 
 
-bool CWeapon::Action(s32 cmd, u32 flags)
+bool CWeapon::Action(s32 cmd, u32 flags) 
 {
-	if (inherited::Action(cmd, flags)) return true;
+	if(inherited::Action(cmd, flags)) return true;
 
-
-	switch (cmd)
+	
+	switch(cmd) 
 	{
-	case kWPN_FIRE:
-	{
-		//если оружие чем-то занято, то ничего не делать
-		{
-			if (flags & CMD_START)
+		case kWPN_FIRE: 
 			{
-				if (IsPending())		return false;
-				FireStart();
-			}
-			else
-				FireEnd();
-		};
+				//если оружие чем-то занято, то ничего не делать
+				{				
+					if(flags&CMD_START) 
+					{
+						if(IsPending())		return false;
+						FireStart			();
+					}else 
+						FireEnd();
+				};
 
-	}
-	return true;
-	case kWPN_NEXT:
-	{
-		if (IsPending() || OnClient())
-		{
-			return false;
-		}
-
-		if (Core.Features.test(xrCore::Feature::lock_reload_in_sprint) && ParentIsActor() && g_actor->get_state() & mcSprint)
+			} 
 			return true;
+		case kWPN_NEXT: 
+			{
+				if(IsPending() || OnClient()) 
+				{
+					return false;
+				}
+									
+				if ( Core.Features.test(xrCore::Feature::lock_reload_in_sprint) && ParentIsActor() && g_actor->get_state() & mcSprint )
+				  return true;
 
-		if (flags & CMD_START)
+				if(flags&CMD_START) 
+				{
+					u32 l_newType = m_ammoType;
+					bool b1, b2;
+					do
+					{
+						l_newType = (l_newType + 1) % m_ammoTypes.size();
+						b1 = l_newType != m_ammoType;
+						b2 = unlimited_ammo() ? false : (!m_pCurrentInventory->GetAmmo(*m_ammoTypes[l_newType], ParentIsActor()));
+					} while (b1 && b2);
+
+					if (l_newType != m_ammoType)
+					{
+						m_set_next_ammoType_on_reload = l_newType;
+						if (OnServer()) Reload();
+					}
+				}
+			} 
+            return true;
+
+		case kWPN_ZOOM:
 		{
-			u32 l_newType = m_ammoType;
-			bool b1, b2;
-			do
+			if (IsZoomEnabled())
 			{
-				l_newType = (l_newType + 1) % m_ammoTypes.size();
-				b1 = l_newType != m_ammoType;
-				b2 = unlimited_ammo() ? false : (!m_pCurrentInventory->GetAmmo(*m_ammoTypes[l_newType], ParentIsActor()));
-			} while (b1 && b2);
-
-			if (l_newType != m_ammoType)
-			{
-				m_set_next_ammoType_on_reload = l_newType;
-				if (OnServer()) Reload();
-			}
-		}
-	}
-	return true;
-
-	case kWPN_ZOOM:
-	{
-		if (IsZoomEnabled())
-		{
-			if (flags & CMD_START && !IsPending())
-			{
-				if (psActorFlags.is(AF_WPN_AIM_TOGGLE) && IsZoomed())
+				if (flags & CMD_START && !IsPending())
+				{
+					if (psActorFlags.is(AF_WPN_AIM_TOGGLE) && IsZoomed())
+					{
+						OnZoomOut();
+					}
+					else
+						OnZoomIn();
+				}
+				else if (IsZoomed() && !psActorFlags.is(AF_WPN_AIM_TOGGLE))
 				{
 					OnZoomOut();
 				}
-				else
-					OnZoomIn();
+				return true;
 			}
-			else if (IsZoomed() && !psActorFlags.is(AF_WPN_AIM_TOGGLE))
-			{
-				OnZoomOut();
-			}
-			return true;
-		}
-		else
-			return false;
-	}
-
-	case kWPN_ZOOM_INC:
-	case kWPN_ZOOM_DEC:
-	{
-		if (IsZoomEnabled() && IsZoomed() && m_bScopeDynamicZoom && IsScopeAttached() && (flags & CMD_START))
-		{
-			// если в режиме ПГ - не будем давать использовать динамический зум
-			if (IsGrenadeMode())
+			else
 				return false;
-
-			ZoomChange(cmd == kWPN_ZOOM_INC);
-
-			return true;
 		}
-		else
-			return false;
-	}
+
+		case kWPN_ZOOM_INC:
+		case kWPN_ZOOM_DEC:
+		{
+			if (IsZoomEnabled() && IsZoomed() && m_bScopeDynamicZoom && IsScopeAttached() && (flags&CMD_START))
+			{
+				// если в режиме ПГ - не будем давать использовать динамический зум
+				if (IsGrenadeMode())
+					return false;
+
+				ZoomChange(cmd == kWPN_ZOOM_INC);
+
+				return true;
+			}
+			else
+				return false;
+		}
 	}
 	return false;
 }
@@ -1069,10 +1068,10 @@ bool CWeapon::Action(s32 cmd, u32 flags)
 void CWeapon::GetZoomData(const float scope_factor, float& delta, float& min_zoom_factor)
 {
 	float def_fov = Core.Features.test(xrCore::Feature::ogse_wpn_zoom_system) ? 1.f : g_fov;
-	float delta_factor_total = def_fov - scope_factor;
-	VERIFY(delta_factor_total > 0);
-	min_zoom_factor = def_fov - delta_factor_total * m_fMinZoomK;
-	delta = (delta_factor_total * (1 - m_fMinZoomK)) / m_fZoomStepCount;
+	float delta_factor_total = def_fov-scope_factor;
+	VERIFY(delta_factor_total>0);
+	min_zoom_factor = def_fov-delta_factor_total*m_fMinZoomK;
+	delta = (delta_factor_total*(1-m_fMinZoomK) )/m_fZoomStepCount;
 }
 
 void CWeapon::ZoomChange(bool inc)
@@ -1125,72 +1124,72 @@ void CWeapon::ZoomChange(bool inc)
 	}
 }
 
-void CWeapon::SpawnAmmo(u32 boxCurr, LPCSTR ammoSect, u32 ParentID)
+void CWeapon::SpawnAmmo(u32 boxCurr, LPCSTR ammoSect, u32 ParentID) 
 {
-	if (!m_ammoTypes.size())			return;
+	if(!m_ammoTypes.size())			return;
 	if (OnClient())					return;
-
+	
 	if (!ammoSect) ammoSect = m_ammoTypes.front().c_str();
+	
+	CSE_Abstract *D					= F_entity_Create(ammoSect);
 
-	CSE_Abstract* D = F_entity_Create(ammoSect);
-
-	if (D->m_tClassID == CLSID_OBJECT_AMMO ||
-		D->m_tClassID == CLSID_OBJECT_A_M209 ||
-		D->m_tClassID == CLSID_OBJECT_A_VOG25 ||
-		D->m_tClassID == CLSID_OBJECT_A_OG7B)
-	{
-		CSE_ALifeItemAmmo* l_pA = smart_cast<CSE_ALifeItemAmmo*>(D);
-		R_ASSERT(l_pA);
-		l_pA->m_boxSize = (u16)pSettings->r_s32(ammoSect, "box_size");
-		D->s_name = ammoSect;
-		D->set_name_replace("");
-		D->s_gameid = u8(GameID());
-		D->s_RP = 0xff;
-		D->ID = 0xffff;
-		if (ParentID == 0xffffffff)
-			D->ID_Parent = (u16)H_Parent()->ID();
+	if (D->m_tClassID==CLSID_OBJECT_AMMO	||
+		D->m_tClassID==CLSID_OBJECT_A_M209	||
+		D->m_tClassID==CLSID_OBJECT_A_VOG25	||
+		D->m_tClassID==CLSID_OBJECT_A_OG7B)
+	{	
+		CSE_ALifeItemAmmo *l_pA		= smart_cast<CSE_ALifeItemAmmo*>(D);
+		R_ASSERT					(l_pA);
+		l_pA->m_boxSize				= (u16)pSettings->r_s32(ammoSect, "box_size");
+		D->s_name					= ammoSect;
+		D->set_name_replace			("");
+		D->s_gameid					= u8(GameID());
+		D->s_RP						= 0xff;
+		D->ID						= 0xffff;
+		if (ParentID == 0xffffffff)	
+			D->ID_Parent			= (u16)H_Parent()->ID();
 		else
-			D->ID_Parent = (u16)ParentID;
+			D->ID_Parent			= (u16)ParentID;
 
-		D->ID_Phantom = 0xffff;
-		D->s_flags.assign(M_SPAWN_OBJECT_LOCAL);
-		D->RespawnTime = 0;
-		l_pA->m_tNodeID = ai_location().level_vertex_id();
+		D->ID_Phantom				= 0xffff;
+		D->s_flags.assign			(M_SPAWN_OBJECT_LOCAL);
+		D->RespawnTime				= 0;
+		l_pA->m_tNodeID				= ai_location().level_vertex_id();
 
-		if (boxCurr == 0xffffffff)
-			boxCurr = l_pA->m_boxSize;
+		if(boxCurr == 0xffffffff) 	
+			boxCurr					= l_pA->m_boxSize;
 
-		while (boxCurr)
+		while(boxCurr) 
 		{
-			l_pA->a_elapsed = (u16)(boxCurr > l_pA->m_boxSize ? l_pA->m_boxSize : boxCurr);
+			l_pA->a_elapsed			= (u16)(boxCurr > l_pA->m_boxSize ? l_pA->m_boxSize : boxCurr);
 			NET_Packet				P;
-			D->Spawn_Write(P, TRUE);
-			Level().Send(P, net_flags(TRUE));
+			D->Spawn_Write			(P, TRUE);
+			Level().Send			(P,net_flags(TRUE));
 
-			if (boxCurr > l_pA->m_boxSize)
-				boxCurr -= l_pA->m_boxSize;
-			else
-				boxCurr = 0;
+			if(boxCurr > l_pA->m_boxSize) 
+				boxCurr				-= l_pA->m_boxSize;
+			else 
+				boxCurr				= 0;
 		}
 	};
-	F_entity_Destroy(D);
+	F_entity_Destroy				(D);
 }
 
 int CWeapon::GetAmmoCurrent(bool use_item_to_spawn) const
 {
 	int l_count = iAmmoElapsed;
-	if (!m_pCurrentInventory) return l_count;
+	if(!m_pCurrentInventory) return l_count;
 
 	//чтоб не делать лишних пересчетов
-	if (m_pCurrentInventory->ModifyFrame() <= m_dwAmmoCurrentCalcFrame)
+	if(m_pCurrentInventory->ModifyFrame()<=m_dwAmmoCurrentCalcFrame)
 		return l_count + iAmmoCurrent;
 
-	m_dwAmmoCurrentCalcFrame = Device.dwFrame;
+ 	m_dwAmmoCurrentCalcFrame = Device.dwFrame;
 	iAmmoCurrent = 0;
 
-	for (int i = 0; i < (int)m_ammoTypes.size(); ++i)
+	for(int i = 0; i < (int)m_ammoTypes.size(); ++i) 
 	{
-		iAmmoCurrent += GetAmmoCount_forType(m_ammoTypes[i]);
+		iAmmoCurrent += GetAmmoCount_forType( m_ammoTypes[i] );
 
 		if (!use_item_to_spawn)
 			continue;
@@ -1203,57 +1202,57 @@ int CWeapon::GetAmmoCurrent(bool use_item_to_spawn) const
 	return l_count + iAmmoCurrent;
 }
 
-int CWeapon::GetAmmoCount(u8 ammo_type, u32 max) const {
-	VERIFY(m_pInventory);
-	R_ASSERT(ammo_type < m_ammoTypes.size());
+int CWeapon::GetAmmoCount( u8 ammo_type, u32 max ) const {
+  VERIFY( m_pInventory );
+  R_ASSERT( ammo_type < m_ammoTypes.size() );
 
-	return GetAmmoCount_forType(m_ammoTypes[ammo_type], max);
+  return GetAmmoCount_forType( m_ammoTypes[ ammo_type ], max );
 }
 
-int CWeapon::GetAmmoCount_forType(shared_str const& ammo_type, u32 max) const {
-	u32 res = 0;
-	auto callback = [&](const auto pIItem) -> bool {
-		auto* ammo = smart_cast<CWeaponAmmo*>(pIItem);
-		if (ammo->cNameSect() == ammo_type)
-			res += ammo->m_boxCurr;
-		return (max > 0 && res >= max);
-	};
+int CWeapon::GetAmmoCount_forType( shared_str const& ammo_type, u32 max ) const {
+  u32 res = 0;
+  auto callback = [&]( const auto pIItem ) -> bool {
+    auto* ammo = smart_cast<CWeaponAmmo*>( pIItem );
+    if ( ammo->cNameSect() == ammo_type )
+      res += ammo->m_boxCurr;
+    return ( max > 0 && res >= max );
+  };
 
-	m_pCurrentInventory->IterateAmmo(false, callback);
-	if (max == 0 || res < max)
-		if (!smart_cast<const CActor*>(H_Parent()) || !psActorFlags.test(AF_AMMO_ON_BELT))
-			m_pCurrentInventory->IterateAmmo(true, callback);
+  m_pCurrentInventory->IterateAmmo( false, callback );
+  if ( max == 0 || res < max )
+    if ( !smart_cast<const CActor*>( H_Parent() ) || !psActorFlags.test( AF_AMMO_ON_BELT ) )
+      m_pCurrentInventory->IterateAmmo( true, callback );
 
-	return res;
+  return res;
 }
 
 float CWeapon::GetConditionMisfireProbability() const
 {
-	if (GetCondition() > 0.95f) return 0.0f;
+	if( GetCondition()>0.95f ) return 0.0f;
 
-	float mis = misfireProbability + powf(1.f - GetCondition(), 3.f) * misfireConditionK;
-	clamp(mis, 0.0f, 0.99f);
+	float mis = misfireProbability+powf(1.f-GetCondition(), 3.f)*misfireConditionK;
+	clamp(mis,0.0f,0.99f);
 	return mis;
 }
 
-BOOL CWeapon::CheckForMisfire()
+BOOL CWeapon::CheckForMisfire	()
 {
 	if (OnClient()) return FALSE;
 
-	if (Core.Features.test(xrCore::Feature::npc_simplified_shooting)) {
-		CActor* actor = smart_cast<CActor*>(H_Parent());
-		if (!actor) return FALSE;
+	if ( Core.Features.test( xrCore::Feature::npc_simplified_shooting ) ) {
+	  CActor *actor = smart_cast<CActor*>( H_Parent() );
+	  if ( !actor ) return FALSE;
 	}
 
-	float rnd = ::Random.randF(0.f, 1.f);
+	float rnd = ::Random.randF(0.f,1.f);
 	float mp = GetConditionMisfireProbability();
-	if (rnd < mp)
+	if(rnd < mp)
 	{
 		FireEnd();
 
 		bMisfire = true;
-		SwitchState(eMisfire);
-
+		SwitchState(eMisfire);		
+		
 		return TRUE;
 	}
 	else
@@ -1263,7 +1262,7 @@ BOOL CWeapon::CheckForMisfire()
 }
 
 BOOL CWeapon::IsMisfire() const
-{
+{	
 	return bMisfire;
 }
 void CWeapon::Reload()
@@ -1275,23 +1274,23 @@ void CWeapon::Reload()
 bool CWeapon::IsGrenadeLauncherAttached() const
 {
 	return (CSE_ALifeItemWeapon::eAddonAttachable == m_eGrenadeLauncherStatus &&
-		0 != (m_flagsAddOnState & CSE_ALifeItemWeapon::eWeaponAddonGrenadeLauncher)) ||
-		CSE_ALifeItemWeapon::eAddonPermanent == m_eGrenadeLauncherStatus;
+			0 != (m_flagsAddOnState&CSE_ALifeItemWeapon::eWeaponAddonGrenadeLauncher)) || 
+			CSE_ALifeItemWeapon::eAddonPermanent == m_eGrenadeLauncherStatus;
 }
 
 bool CWeapon::IsScopeAttached() const
 {
 	return (CSE_ALifeItemWeapon::eAddonAttachable == m_eScopeStatus &&
-		0 != (m_flagsAddOnState & CSE_ALifeItemWeapon::eWeaponAddonScope)) ||
-		CSE_ALifeItemWeapon::eAddonPermanent == m_eScopeStatus;
+			0 != (m_flagsAddOnState&CSE_ALifeItemWeapon::eWeaponAddonScope)) || 
+			CSE_ALifeItemWeapon::eAddonPermanent == m_eScopeStatus;
 
 }
 
 bool CWeapon::IsSilencerAttached() const
 {
 	return (CSE_ALifeItemWeapon::eAddonAttachable == m_eSilencerStatus &&
-		0 != (m_flagsAddOnState & CSE_ALifeItemWeapon::eWeaponAddonSilencer)) ||
-		CSE_ALifeItemWeapon::eAddonPermanent == m_eSilencerStatus;
+			0 != (m_flagsAddOnState&CSE_ALifeItemWeapon::eWeaponAddonSilencer)) || 
+			CSE_ALifeItemWeapon::eAddonPermanent == m_eSilencerStatus;
 }
 
 bool CWeapon::GrenadeLauncherAttachable() const
@@ -1333,7 +1332,7 @@ void CWeapon::UpdateHUDAddonsVisibility()
 
 	if (GrenadeLauncherAttachable())
 		HudItemData()->set_bone_visible(m_sHud_wpn_launcher_bone, IsGrenadeLauncherAttached());
-
+	
 	if (m_eGrenadeLauncherStatus == ALife::eAddonDisabled)
 		HudItemData()->set_bone_visible(m_sHud_wpn_launcher_bone, FALSE, TRUE);
 	else if (m_eGrenadeLauncherStatus == ALife::eAddonPermanent)
@@ -1439,10 +1438,10 @@ void CWeapon::UpdateAddonsVisibility()
 }
 
 
-bool CWeapon::Activate(bool now)
+bool CWeapon::Activate( bool now ) 
 {
 	UpdateAddonsVisibility();
-	return inherited::Activate(now);
+	return inherited::Activate( now );
 }
 
 void CWeapon::InitAddons()
@@ -1464,7 +1463,7 @@ void CWeapon::OnZoomIn()
 	m_bZoomMode = true;
 
 	// если в режиме ПГ - не будем давать включать динамический зум
-	if (m_bScopeDynamicZoom && !IsGrenadeMode() && !SecondVPEnabled())
+	if ( m_bScopeDynamicZoom && !IsGrenadeMode() && !SecondVPEnabled())
 		m_fZoomFactor = m_fRTZoomFactor;
 	else
 		m_fZoomFactor = CurrentZoomFactor();
@@ -1476,11 +1475,11 @@ void CWeapon::OnZoomIn()
 	else if (!m_bZoomInertionAllow)
 		AllowHudInertion(FALSE);
 
-	if (GetHUDmode())
+	if(GetHUDmode())
 		GamePersistent().SetPickableEffectorDOF(true);
 
 	CActor* pActor = smart_cast<CActor*>(H_Parent());
-	if (pActor)
+	if ( pActor )
 		pActor->callback(GameObject::eOnActorWeaponZoomIn)(lua_game_object());
 }
 
@@ -1488,13 +1487,13 @@ void CWeapon::OnZoomOut()
 {
 	m_fZoomFactor = Core.Features.test(xrCore::Feature::ogse_wpn_zoom_system) ? 1.f : g_fov;
 
-	if (m_bZoomMode) {
+	if ( m_bZoomMode ) {
 
 		m_bZoomMode = false;
 
 		CActor* pActor = smart_cast<CActor*>(H_Parent());
-		if (pActor) {
-			w_states.set(0.f, 0.f, 0.f, 1.f);
+		if ( pActor ) {
+			w_states.set( 0.f, 0.f, 0.f, 1.f );
 			pActor->callback(GameObject::eOnActorWeaponZoomOut)(lua_game_object());
 		}
 	}
@@ -1508,7 +1507,7 @@ void CWeapon::OnZoomOut()
 }
 
 bool CWeapon::UseScopeTexture() {
-	return ((GetAddonsState() & CSE_ALifeItemWeapon::eForcedNotexScope) == 0)
+	return (( GetAddonsState() & CSE_ALifeItemWeapon::eForcedNotexScope ) == 0) 
 		&& !SecondVPEnabled()
 		&& m_UIScope; // только если есть текстура прицела - для простого создания коллиматоров
 };
@@ -1525,87 +1524,87 @@ void CWeapon::SwitchState(u32 S)
 {
 	if (OnClient()) return;
 
-	SetNextState(S);	// Very-very important line of code!!! :)
-	if (CHudItem::object().Local() && !CHudItem::object().getDestroy()/* && (S!=NEXT_STATE)*/
-		&& m_pCurrentInventory && OnServer())
+	SetNextState		( S );	// Very-very important line of code!!! :)
+	if (CHudItem::object().Local() && !CHudItem::object().getDestroy()/* && (S!=NEXT_STATE)*/ 
+		&& m_pCurrentInventory && OnServer())	
 	{
 		// !!! Just single entry for given state !!!
 		NET_Packet		P;
-		CHudItem::object().u_EventGen(P, GE_WPN_STATE_CHANGE, CHudItem::object().ID());
-		P.w_u8(u8(S));
-		P.w_u8(u8(m_sub_state));
-		P.w_u8(u8(m_ammoType & 0xff));
-		P.w_u8(u8(iAmmoElapsed & 0xff));
-		P.w_u8(u8(m_set_next_ammoType_on_reload & 0xff));
-		CHudItem::object().u_EventSend(P, net_flags(TRUE, TRUE, FALSE, TRUE));
+		CHudItem::object().u_EventGen		(P,GE_WPN_STATE_CHANGE,CHudItem::object().ID());
+		P.w_u8			(u8(S));
+		P.w_u8			(u8(m_sub_state));
+		P.w_u8			(u8(m_ammoType& 0xff));
+		P.w_u8			(u8(iAmmoElapsed & 0xff));
+		P.w_u8			(u8(m_set_next_ammoType_on_reload & 0xff));
+		CHudItem::object().u_EventSend		(P, net_flags(TRUE, TRUE, FALSE, TRUE));
 	}
 }
 
-void CWeapon::OnMagazineEmpty()
+void CWeapon::OnMagazineEmpty	()
 {
 	VERIFY((u32)iAmmoElapsed == m_magazine.size());
 }
 
 
-void CWeapon::reinit()
+void CWeapon::reinit			()
 {
-	CShootingObject::reinit();
-	CHudItemObject::reinit();
+	CShootingObject::reinit		();
+	CHudItemObject::reinit			();
 }
 
-void CWeapon::reload(LPCSTR section)
+void CWeapon::reload			(LPCSTR section)
 {
-	CShootingObject::reload(section);
-	CHudItemObject::reload(section);
-
-	m_can_be_strapped = true;
-	m_strapped_mode = false;
-
-	if (pSettings->line_exist(section, "strap_bone0"))
-		m_strap_bone0 = pSettings->r_string(section, "strap_bone0");
+	CShootingObject::reload		(section);
+	CHudItemObject::reload			(section);
+	
+	m_can_be_strapped			= true;
+	m_strapped_mode				= false;
+	
+	if (pSettings->line_exist(section,"strap_bone0"))
+		m_strap_bone0			= pSettings->r_string(section,"strap_bone0");
 	else
-		m_can_be_strapped = false;
-
-	if (pSettings->line_exist(section, "strap_bone1"))
-		m_strap_bone1 = pSettings->r_string(section, "strap_bone1");
+		m_can_be_strapped		= false;
+	
+	if (pSettings->line_exist(section,"strap_bone1"))
+		m_strap_bone1			= pSettings->r_string(section,"strap_bone1");
 	else
-		m_can_be_strapped = false;
+		m_can_be_strapped		= false;
 
 	if (m_eScopeStatus == ALife::eAddonAttachable) {
-		m_addon_holder_range_modifier = READ_IF_EXISTS(pSettings, r_float, m_sScopeName, "holder_range_modifier", m_holder_range_modifier);
-		m_addon_holder_fov_modifier = READ_IF_EXISTS(pSettings, r_float, m_sScopeName, "holder_fov_modifier", m_holder_fov_modifier);
+		m_addon_holder_range_modifier	= READ_IF_EXISTS(pSettings,r_float,m_sScopeName,"holder_range_modifier",m_holder_range_modifier);
+		m_addon_holder_fov_modifier		= READ_IF_EXISTS(pSettings,r_float,m_sScopeName,"holder_fov_modifier",m_holder_fov_modifier);
 	}
 	else {
-		m_addon_holder_range_modifier = m_holder_range_modifier;
-		m_addon_holder_fov_modifier = m_holder_fov_modifier;
+		m_addon_holder_range_modifier	= m_holder_range_modifier;
+		m_addon_holder_fov_modifier		= m_holder_fov_modifier;
 	}
 
 
 	{
-		Fvector				pos, ypr;
-		pos = pSettings->r_fvector3(section, "position");
-		ypr = pSettings->r_fvector3(section, "orientation");
-		ypr.mul(PI / 180.f);
+		Fvector				pos,ypr;
+		pos					= pSettings->r_fvector3		(section,"position");
+		ypr					= pSettings->r_fvector3		(section,"orientation");
+		ypr.mul				(PI/180.f);
 
-		m_Offset.setHPB(ypr.x, ypr.y, ypr.z);
-		m_Offset.translate_over(pos);
+		m_Offset.setHPB			(ypr.x,ypr.y,ypr.z);
+		m_Offset.translate_over	(pos);
 	}
 
-	m_StrapOffset = m_Offset;
-	if (pSettings->line_exist(section, "strap_position") && pSettings->line_exist(section, "strap_orientation")) {
-		Fvector				pos, ypr;
-		pos = pSettings->r_fvector3(section, "strap_position");
-		ypr = pSettings->r_fvector3(section, "strap_orientation");
-		ypr.mul(PI / 180.f);
+	m_StrapOffset			= m_Offset;
+	if (pSettings->line_exist(section,"strap_position") && pSettings->line_exist(section,"strap_orientation")) {
+		Fvector				pos,ypr;
+		pos					= pSettings->r_fvector3		(section,"strap_position");
+		ypr					= pSettings->r_fvector3		(section,"strap_orientation");
+		ypr.mul				(PI/180.f);
 
-		m_StrapOffset.setHPB(ypr.x, ypr.y, ypr.z);
-		m_StrapOffset.translate_over(pos);
+		m_StrapOffset.setHPB			(ypr.x,ypr.y,ypr.z);
+		m_StrapOffset.translate_over	(pos);
 	}
 	else
-		m_can_be_strapped = false;
+		m_can_be_strapped	= false;
 
-	m_ef_main_weapon_type = READ_IF_EXISTS(pSettings, r_u32, section, "ef_main_weapon_type", u32(-1));
-	m_ef_weapon_type = READ_IF_EXISTS(pSettings, r_u32, section, "ef_weapon_type", u32(-1));
+	m_ef_main_weapon_type	= READ_IF_EXISTS(pSettings,r_u32,section,"ef_main_weapon_type",u32(-1));
+	m_ef_weapon_type		= READ_IF_EXISTS(pSettings,r_u32,section,"ef_weapon_type",u32(-1));
 }
 
 void CWeapon::create_physic_shell()
@@ -1623,7 +1622,7 @@ void CWeapon::setup_physic_shell()
 	CPhysicsShellHolder::setup_physic_shell();
 }
 
-bool CWeapon::can_kill() const
+bool CWeapon::can_kill	() const
 {
 	if (GetAmmoCurrent(true) || m_ammoTypes.empty())
 		return				(true);
@@ -1631,19 +1630,19 @@ bool CWeapon::can_kill() const
 	return					(false);
 }
 
-CInventoryItem* CWeapon::can_kill(CInventory* inventory) const
+CInventoryItem *CWeapon::can_kill	(CInventory *inventory) const
 {
 	if (GetAmmoElapsed() || m_ammoTypes.empty())
 		return				(const_cast<CWeapon*>(this));
 
 	TIItemContainer::iterator I = inventory->m_all.begin();
 	TIItemContainer::iterator E = inventory->m_all.end();
-	for (; I != E; ++I) {
-		CInventoryItem* inventory_item = smart_cast<CInventoryItem*>(*I);
+	for ( ; I != E; ++I) {
+		CInventoryItem	*inventory_item = smart_cast<CInventoryItem*>(*I);
 		if (!inventory_item)
 			continue;
-
-		xr_vector<shared_str>::const_iterator	i = std::find(m_ammoTypes.begin(), m_ammoTypes.end(), inventory_item->object().cNameSect());
+		
+		xr_vector<shared_str>::const_iterator	i = std::find(m_ammoTypes.begin(),m_ammoTypes.end(),inventory_item->object().cNameSect());
 		if (i != m_ammoTypes.end())
 			return			(inventory_item);
 	}
@@ -1651,19 +1650,19 @@ CInventoryItem* CWeapon::can_kill(CInventory* inventory) const
 	return					(0);
 }
 
-const CInventoryItem* CWeapon::can_kill(const xr_vector<const CGameObject*>& items) const
+const CInventoryItem *CWeapon::can_kill	(const xr_vector<const CGameObject*> &items) const
 {
 	if (m_ammoTypes.empty())
 		return				(this);
 
 	xr_vector<const CGameObject*>::const_iterator I = items.begin();
 	xr_vector<const CGameObject*>::const_iterator E = items.end();
-	for (; I != E; ++I) {
-		const CInventoryItem* inventory_item = smart_cast<const CInventoryItem*>(*I);
+	for ( ; I != E; ++I) {
+		const CInventoryItem	*inventory_item = smart_cast<const CInventoryItem*>(*I);
 		if (!inventory_item)
 			continue;
 
-		xr_vector<shared_str>::const_iterator	i = std::find(m_ammoTypes.begin(), m_ammoTypes.end(), inventory_item->object().cNameSect());
+		xr_vector<shared_str>::const_iterator	i = std::find(m_ammoTypes.begin(),m_ammoTypes.end(),inventory_item->object().cNameSect());
 		if (i != m_ammoTypes.end())
 			return			(inventory_item);
 	}
@@ -1671,13 +1670,13 @@ const CInventoryItem* CWeapon::can_kill(const xr_vector<const CGameObject*>& ite
 	return					(0);
 }
 
-bool CWeapon::ready_to_kill() const
+bool CWeapon::ready_to_kill	() const
 {
 	return					(
-		!IsMisfire() &&
-		((GetState() == eIdle) || (GetState() == eFire) || (GetState() == eFire2)) &&
+		!IsMisfire() && 
+		((GetState() == eIdle) || (GetState() == eFire) || (GetState() == eFire2)) && 
 		GetAmmoElapsed()
-		);
+	);
 }
 
 // Получить индекс текущих координат худа
@@ -1718,16 +1717,16 @@ u8 CWeapon::GetCurrentHudOffsetIdx()
 
 
 // Обновление координат текущего худа
-void CWeapon::UpdateHudAdditonal(Fmatrix& trans)
+void CWeapon::UpdateHudAdditonal		(Fmatrix& trans)
 {
 	auto pActor = smart_cast<const CActor*>(H_Parent());
-	if (!pActor) return;
+	if(!pActor) return;
 
 	u8 idx = GetCurrentHudOffsetIdx();
 
 	//============= Поворот ствола во время аима =============//
-	if ((pActor->IsZoomAimingMode() && m_fZoomRotationFactor <= 1.f) ||
-		(!pActor->IsZoomAimingMode() && m_fZoomRotationFactor > 0.f))
+	if(		(pActor->IsZoomAimingMode() && m_fZoomRotationFactor<=1.f) ||
+			(!pActor->IsZoomAimingMode() && m_fZoomRotationFactor>0.f))
 	{
 		attachable_hud_item* hi = HudItemData();
 		R_ASSERT(hi);
@@ -1753,13 +1752,13 @@ void CWeapon::UpdateHudAdditonal(Fmatrix& trans)
 		hud_rotation.translate_over(curr_offs);
 		trans.mulB_43(hud_rotation);
 
-		if (pActor->IsZoomAimingMode())
+		if(pActor->IsZoomAimingMode())
 		{
-			m_fZoomRotationFactor += Device.fTimeDelta / m_fZoomRotateTime;
+			m_fZoomRotationFactor += Device.fTimeDelta/m_fZoomRotateTime;
 		}
 		else
 		{
-			m_fZoomRotationFactor -= Device.fTimeDelta / m_fZoomRotateTime;
+			m_fZoomRotationFactor -= Device.fTimeDelta/m_fZoomRotateTime;
 		}
 		clamp(m_fZoomRotationFactor, 0.f, 1.f);
 	}
@@ -1896,18 +1895,18 @@ void CWeapon::UpdateHudAdditonal(Fmatrix& trans)
 	}
 }
 
-void	CWeapon::SetAmmoElapsed(int ammo_count)
+void	CWeapon::SetAmmoElapsed	(int ammo_count)
 {
-	iAmmoElapsed = ammo_count;
+	iAmmoElapsed				= ammo_count;
 
-	u32 uAmmo = u32(iAmmoElapsed);
+	u32 uAmmo					= u32(iAmmoElapsed);
 
 	if (uAmmo != m_magazine.size())
 	{
 		if (uAmmo > m_magazine.size())
 		{
-			CCartridge			l_cartridge;
-			l_cartridge.Load(*m_ammoTypes[m_ammoType], u8(m_ammoType));
+			CCartridge			l_cartridge; 
+			l_cartridge.Load	(*m_ammoTypes[m_ammoType], u8(m_ammoType));
 			while (uAmmo > m_magazine.size())
 				m_magazine.push_back(l_cartridge);
 		}
@@ -1919,93 +1918,93 @@ void	CWeapon::SetAmmoElapsed(int ammo_count)
 	};
 }
 
-u32	CWeapon::ef_main_weapon_type() const
+u32	CWeapon::ef_main_weapon_type	() const
 {
-	VERIFY(m_ef_main_weapon_type != u32(-1));
+	VERIFY	(m_ef_main_weapon_type != u32(-1));
 	return	(m_ef_main_weapon_type);
 }
 
-u32	CWeapon::ef_weapon_type() const
+u32	CWeapon::ef_weapon_type	() const
 {
-	VERIFY(m_ef_weapon_type != u32(-1));
+	VERIFY	(m_ef_weapon_type != u32(-1));
 	return	(m_ef_weapon_type);
 }
 
-bool CWeapon::IsNecessaryItem(const shared_str& item_sect)
+bool CWeapon::IsNecessaryItem	    (const shared_str& item_sect)
 {
-	return (std::find(m_ammoTypes.begin(), m_ammoTypes.end(), item_sect) != m_ammoTypes.end());
+	return (std::find(m_ammoTypes.begin(), m_ammoTypes.end(), item_sect) != m_ammoTypes.end() );
 }
 
-void CWeapon::modify_holder_params(float& range, float& fov) const
+void CWeapon::modify_holder_params		(float &range, float &fov) const
 {
 	if (!IsScopeAttached()) {
-		inherited::modify_holder_params(range, fov);
+		inherited::modify_holder_params	(range,fov);
 		return;
 	}
-	range *= m_addon_holder_range_modifier;
-	fov *= m_addon_holder_fov_modifier;
+	range	*= m_addon_holder_range_modifier;
+	fov		*= m_addon_holder_fov_modifier;
 }
 
 void CWeapon::OnDrawUI()
 {
-	if (IsZoomed() && ZoomHideCrosshair()) {
-		if (ZoomTexture() && !IsRotatingToZoom()) {
-			ZoomTexture()->SetPos(0, 0);
-			ZoomTexture()->SetRect(0, 0, UI_BASE_WIDTH, UI_BASE_HEIGHT);
-			ZoomTexture()->Render();
+	if(IsZoomed() && ZoomHideCrosshair()){
+		if(ZoomTexture() && !IsRotatingToZoom()){
+			ZoomTexture()->SetPos	(0,0);
+			ZoomTexture()->SetRect	(0,0,UI_BASE_WIDTH, UI_BASE_HEIGHT);
+			ZoomTexture()->Render	();
 
-			//			m_UILens.Draw();
+//			m_UILens.Draw();
 		}
 	}
 }
 
 bool CWeapon::IsHudModeNow()
-{
+{ 
 	return (HudItemData() != nullptr);
 }
 
-bool CWeapon::unlimited_ammo()
-{
+bool CWeapon::unlimited_ammo() 
+{ 
 	if (m_pCurrentInventory)
 		return inventory_owner().unlimited_ammo() && m_DefaultCartridge.m_flags.test(CCartridge::cfCanBeUnlimited);
 	else
 		return false;
 };
 
-LPCSTR	CWeapon::GetCurrentAmmo_ShortName()
+LPCSTR	CWeapon::GetCurrentAmmo_ShortName	()
 {
 	if (m_magazine.empty()) return ("");
-	CCartridge& l_cartridge = m_magazine.back();
+	CCartridge &l_cartridge = m_magazine.back();
 	return *(l_cartridge.m_InvShortName);
 }
 
 float CWeapon::GetMagazineWeight(const decltype(CWeapon::m_magazine)& mag) const
 {
-	float res = 0;
-	const char* last_type = nullptr;
-	float last_ammo_weight = 0;
-	for (auto& c : mag)
-	{
-		// Usually ammos in mag have same type, use this fact to improve performance
-		if (last_type != c.m_ammoSect.c_str())
-		{
-			last_type = c.m_ammoSect.c_str();
-			last_ammo_weight = c.Weight();
-		}
-		res += last_ammo_weight;
-	}
-	return res;
+    float res = 0;
+    const char* last_type = nullptr;
+    float last_ammo_weight = 0;
+    for (auto& c : mag)
+    {
+        // Usually ammos in mag have same type, use this fact to improve performance
+        if (last_type != c.m_ammoSect.c_str())
+        {
+            last_type = c.m_ammoSect.c_str();
+            last_ammo_weight = c.Weight();
+        }
+        res += last_ammo_weight;
+    }
+    return res;
 }
 
 float CWeapon::Weight() const
 {
 	float res = CInventoryItemObject::Weight();
-	if (GrenadeLauncherAttachable() && IsGrenadeLauncherAttached())
-		res += pSettings->r_float(GetGrenadeLauncherName(), "inv_weight");
-	if (ScopeAttachable() && IsScopeAttached())
-		res += pSettings->r_float(GetScopeName(), "inv_weight");
-	if (SilencerAttachable() && IsSilencerAttached())
-		res += pSettings->r_float(GetSilencerName(), "inv_weight");
+	if ( GrenadeLauncherAttachable() && IsGrenadeLauncherAttached() )
+		res += pSettings->r_float(GetGrenadeLauncherName(),"inv_weight");
+	if ( ScopeAttachable() && IsScopeAttached() )
+		res += pSettings->r_float(GetScopeName(),"inv_weight");
+	if ( SilencerAttachable() && IsSilencerAttached() )
+		res += pSettings->r_float(GetSilencerName(),"inv_weight");
 	res += GetMagazineWeight(m_magazine);
 
 	return res;
@@ -2014,7 +2013,7 @@ float CWeapon::Weight() const
 u32 CWeapon::Cost() const
 {
 	u32 res = m_cost;
-
+	
 	if (Core.Features.test(xrCore::Feature::wpn_cost_include_addons)) {
 		if (GrenadeLauncherAttachable() && IsGrenadeLauncherAttached())
 			res += pSettings->r_u32(GetGrenadeLauncherName(), "cost");
@@ -2055,7 +2054,7 @@ void CWeapon::Show(bool now)
 
 bool CWeapon::show_crosshair()
 {
-	return !(IsZoomed() && ZoomHideCrosshair());
+	return ! ( IsZoomed() && ZoomHideCrosshair() );
 }
 
 bool CWeapon::show_indicators()
@@ -2063,31 +2062,31 @@ bool CWeapon::show_indicators()
 	return !(IsZoomed() && (ZoomTexture() || !m_bScopeShowIndicators));
 }
 
-float CWeapon::GetConditionToShow() const
+float CWeapon::GetConditionToShow	() const
 {
 	return	(GetCondition());//powf(GetCondition(),4.0f));
 }
 
-BOOL CWeapon::ParentMayHaveAimBullet()
+BOOL CWeapon::ParentMayHaveAimBullet	()
 {
-	CObject* O = H_Parent();
+	CObject* O=H_Parent();
 	if (!O) return FALSE;
-	CEntityAlive* EA = smart_cast<CEntityAlive*>(O);
-	return EA->cast_actor() != 0;
+	CEntityAlive* EA=smart_cast<CEntityAlive*>(O);
+	return EA->cast_actor()!=0;
 }
 
-BOOL CWeapon::ParentIsActor()
+BOOL CWeapon::ParentIsActor	()
 {
-	CObject* O = H_Parent();
+	CObject* O=H_Parent();
 	if (!O) return FALSE;
-	CEntityAlive* EA = smart_cast<CEntityAlive*>(O);
+	CEntityAlive* EA=smart_cast<CEntityAlive*>(O);
 	if (!EA) return FALSE;
-	return EA->cast_actor() != 0;
+	return EA->cast_actor()!=0;
 }
 
-const float& CWeapon::hit_probability() const
+const float &CWeapon::hit_probability	() const
 {
-	VERIFY((g_SingleGameDifficulty >= egdNovice) && (g_SingleGameDifficulty <= egdMaster));
+	VERIFY					((g_SingleGameDifficulty >= egdNovice) && (g_SingleGameDifficulty <= egdMaster)); 
 	return					(m_hit_probability[egdNovice]);
 }
 
@@ -2100,14 +2099,14 @@ void CWeapon::StateSwitchCallback(GameObject::ECallbackType actor_type, GameObje
 		{
 			Actor()->callback(actor_type)(
 				lua_game_object()  // The weapon as a game object.
-				);
+			);
 		}
 		else if (smart_cast<CEntityAlive*>(H_Parent()))  // This is an NPC.
 		{
 			Actor()->callback(npc_type)(
 				smart_cast<CEntityAlive*>(H_Parent())->lua_game_object(),       // The owner of the weapon.
 				lua_game_object()                                              // The weapon itself.
-				);
+			);
 		}
 	}
 }
@@ -2133,7 +2132,7 @@ void CWeapon::UpdateSecondVP()
 }
 
 bool CWeapon::SecondVPEnabled() const
-{
+{	
 	bool bCond_2 = m_fSecondVPZoomFactor > 0.0f;     // В конфиге должен быть прописан фактор зума (scope_lense_fov_factor) больше чем 0
 	bool bCond_4 = !IsGrenadeMode();     // Мы не должны быть в режиме подствольника
 	bool bcond_6 = psActorFlags.test(AF_3D_SCOPES);
@@ -2221,16 +2220,16 @@ float CWeapon::GetHudFov()
 	}
 
 	// От бедра	 
-	return m_nearwall_last_hud_fov; 
+	return m_nearwall_last_hud_fov;
 }
 
 
 void CWeapon::OnBulletHit() {
-	if (!fis_zero(conditionDecreasePerShotOnHit))
-		ChangeCondition(-conditionDecreasePerShotOnHit);
+  if ( !fis_zero( conditionDecreasePerShotOnHit ) )
+    ChangeCondition( -conditionDecreasePerShotOnHit );
 }
 
 
 bool CWeapon::IsPartlyReloading() {
-	return (m_set_next_ammoType_on_reload == u32(-1) && GetAmmoElapsed() > 0 && !IsMisfire());
+  return ( m_set_next_ammoType_on_reload == u32(-1) && GetAmmoElapsed() > 0 && !IsMisfire() );
 }

--- a/ogsr_engine/xrGame/Weapon.cpp
+++ b/ogsr_engine/xrGame/Weapon.cpp
@@ -1878,9 +1878,9 @@ void CWeapon::UpdateHudAdditonal		(Fmatrix& trans)
 		trans.mulB_43(hud_rotation);
 	}
 
-	bool bEnabled = m_longitudinal_offset[4 + idx];
+	bool bEnabled = m_longitudinal_offset[4 + idx];	
 	if (bEnabled)
-	{
+	{ // Смещение худа при движении вперёд/назад
 		float curr_offs;
 		curr_offs = m_longitudinal_offset[idx];
 		curr_offs *= m_fFB_MovingFactor;

--- a/ogsr_engine/xrGame/Weapon.cpp
+++ b/ogsr_engine/xrGame/Weapon.cpp
@@ -45,55 +45,55 @@ extern ENGINE_API Fvector3 w_timers;
 
 CWeapon::CWeapon(LPCSTR name) : m_fLR_MovingFactor(0.f), m_strafe_offset{}
 {
-	SetState				(eHidden);
-	SetNextState			(eHidden);
-	m_sub_state				= eSubstateReloadBegin;
-	m_idle_state				= eIdle;
-	m_bTriStateReload		= false;
-	SetDefaults				();
+	SetState(eHidden);
+	SetNextState(eHidden);
+	m_sub_state = eSubstateReloadBegin;
+	m_idle_state = eIdle;
+	m_bTriStateReload = false;
+	SetDefaults();
 
-	m_Offset.identity		();
-	m_StrapOffset.identity	();
+	m_Offset.identity();
+	m_StrapOffset.identity();
 
-	iAmmoCurrent			= -1;
-	m_dwAmmoCurrentCalcFrame= 0;
+	iAmmoCurrent = -1;
+	m_dwAmmoCurrentCalcFrame = 0;
 
-	iAmmoElapsed			= -1;
-	iMagazineSize			= -1;
-	m_ammoType				= 0;
+	iAmmoElapsed = -1;
+	iMagazineSize = -1;
+	m_ammoType = 0;
 
-	eHandDependence			= hdNone;
+	eHandDependence = hdNone;
 
 	m_fZoomFactor = Core.Features.test(xrCore::Feature::ogse_wpn_zoom_system) ? 1.f : g_fov;
 
-	m_fZoomRotationFactor	= 0.f;
+	m_fZoomRotationFactor = 0.f;
 
 
-	m_pAmmo					= nullptr;
+	m_pAmmo = nullptr;
 
 
-	m_pFlameParticles2		= nullptr;
-	m_sFlameParticles2		= nullptr;
+	m_pFlameParticles2 = nullptr;
+	m_sFlameParticles2 = nullptr;
 
 
 	m_fCurrentCartirdgeDisp = 1.f;
 
-	m_strap_bone0			= nullptr;
-	m_strap_bone1			= nullptr;
-	m_StrapOffset.identity	();
-	m_strapped_mode			= false;
-	m_can_be_strapped		= false;
-	m_ef_main_weapon_type	= u32(-1);
-	m_ef_weapon_type		= u32(-1);
-	m_UIScope				= nullptr;
+	m_strap_bone0 = nullptr;
+	m_strap_bone1 = nullptr;
+	m_StrapOffset.identity();
+	m_strapped_mode = false;
+	m_can_be_strapped = false;
+	m_ef_main_weapon_type = u32(-1);
+	m_ef_weapon_type = u32(-1);
+	m_UIScope = nullptr;
 	m_set_next_ammoType_on_reload = u32(-1);
 
 	m_nearwall_last_hud_fov = psHUD_FOV_def;
 }
 
-CWeapon::~CWeapon		()
+CWeapon::~CWeapon()
 {
-	xr_delete	(m_UIScope);
+	xr_delete(m_UIScope);
 }
 
 //void CWeapon::Hit(float P, Fvector &dir,	
@@ -101,74 +101,74 @@ CWeapon::~CWeapon		()
 //		    Fvector position_in_object_space, 
 //		    float impulse, 
 //		    ALife::EHitType hit_type)
-void CWeapon::Hit					(SHit* pHDS)
+void CWeapon::Hit(SHit* pHDS)
 {
-//	inherited::Hit(P, dir, who, element, position_in_object_space,impulse,hit_type);
+	//	inherited::Hit(P, dir, who, element, position_in_object_space,impulse,hit_type);
 	inherited::Hit(pHDS);
 }
 
 
 
-void CWeapon::UpdateXForm	()
+void CWeapon::UpdateXForm()
 {
-	if (Device.dwFrame!=dwXF_Frame)
+	if (Device.dwFrame != dwXF_Frame)
 	{
 		dwXF_Frame = Device.dwFrame;
 
-		if (0==H_Parent())	return;
+		if (0 == H_Parent())	return;
 
 		// Get access to entity and its visual
-		CEntityAlive*	E		= smart_cast<CEntityAlive*>(H_Parent());
-		
-		if(!E) 
+		CEntityAlive* E = smart_cast<CEntityAlive*>(H_Parent());
+
+		if (!E)
 			return;
 
-		const CInventoryOwner	*parent = smart_cast<const CInventoryOwner*>(E);
+		const CInventoryOwner* parent = smart_cast<const CInventoryOwner*>(E);
 		if (!parent || parent && parent->use_simplified_visual())
 			return;
 
 		if (parent->attached(this))
 			return;
 
-		R_ASSERT		(E);
-		IKinematics*	V		= smart_cast<IKinematics*>	(E->Visual());
-		VERIFY			(V);
+		R_ASSERT(E);
+		IKinematics* V = smart_cast<IKinematics*>	(E->Visual());
+		VERIFY(V);
 
 		// Get matrices
-		int				boneL,boneR,boneR2;
-		E->g_WeaponBones(boneL,boneR,boneR2);
+		int				boneL, boneR, boneR2;
+		E->g_WeaponBones(boneL, boneR, boneR2);
 		if ((HandDependence() == hd1Hand) || (GetState() == eReload) || (!E->g_Alive()))
 			boneL = boneR2;
 #pragma todo("TO ALL: serious performance problem")
 		// от mortan:
 		// https://www.gameru.net/forum/index.php?s=&showtopic=23443&view=findpost&p=1677678
 		V->CalculateBones_Invalidate();
-		V->CalculateBones( true ); //V->CalculateBones	();
-		Fmatrix& mL			= V->LL_GetTransform(u16(boneL));
-		Fmatrix& mR			= V->LL_GetTransform(u16(boneR));
+		V->CalculateBones(true); //V->CalculateBones	();
+		Fmatrix& mL = V->LL_GetTransform(u16(boneL));
+		Fmatrix& mR = V->LL_GetTransform(u16(boneR));
 		// Calculate
 		Fmatrix				mRes;
-		Fvector				R,D,N;
-		D.sub				(mL.c,mR.c);	
+		Fvector				R, D, N;
+		D.sub(mL.c, mR.c);
 
-		if(fis_zero(D.magnitude()))
+		if (fis_zero(D.magnitude()))
 		{
 			mRes.set(E->XFORM());
 			mRes.c.set(mR.c);
 		}
 		else
-		{		
+		{
 			D.normalize();
-			R.crossproduct	(mR.j,D);
+			R.crossproduct(mR.j, D);
 
-			N.crossproduct	(D,R);			
+			N.crossproduct(D, R);
 			N.normalize();
 
-			mRes.set		(R,N,D,mR.c);
-			mRes.mulA_43	(E->XFORM());
+			mRes.set(R, N, D, mR.c);
+			mRes.mulA_43(E->XFORM());
 		}
 
-		UpdatePosition	(mRes);
+		UpdatePosition(mRes);
 	}
 }
 
@@ -232,12 +232,12 @@ constexpr char* wpn_silencer_def_bone = "wpn_silencer";
 constexpr char* wpn_launcher_def_bone_shoc = "wpn_launcher";
 constexpr char* wpn_launcher_def_bone_cop = "wpn_grenade_launcher";
 
-void CWeapon::Load		(LPCSTR section)
+void CWeapon::Load(LPCSTR section)
 {
-	inherited::Load					(section);
-	CShootingObject::Load			(section);
+	inherited::Load(section);
+	CShootingObject::Load(section);
 
-	if(pSettings->line_exist(section, "flame_particles_2"))
+	if (pSettings->line_exist(section, "flame_particles_2"))
 		m_sFlameParticles2 = pSettings->r_string(section, "flame_particles_2");
 
 	if (!m_bForcedParticlesHudMode)
@@ -245,109 +245,109 @@ void CWeapon::Load		(LPCSTR section)
 
 #ifdef DEBUG
 	{
-		Fvector				pos,ypr;
-		pos					= pSettings->r_fvector3		(section,"position");
-		ypr					= pSettings->r_fvector3		(section,"orientation");
-		ypr.mul				(PI/180.f);
+		Fvector				pos, ypr;
+		pos = pSettings->r_fvector3(section, "position");
+		ypr = pSettings->r_fvector3(section, "orientation");
+		ypr.mul(PI / 180.f);
 
-		m_Offset.setHPB			(ypr.x,ypr.y,ypr.z);
-		m_Offset.translate_over	(pos);
+		m_Offset.setHPB(ypr.x, ypr.y, ypr.z);
+		m_Offset.translate_over(pos);
 	}
 
-	m_StrapOffset			= m_Offset;
-	if (pSettings->line_exist(section,"strap_position") && pSettings->line_exist(section,"strap_orientation")) {
-		Fvector				pos,ypr;
-		pos					= pSettings->r_fvector3		(section,"strap_position");
-		ypr					= pSettings->r_fvector3		(section,"strap_orientation");
-		ypr.mul				(PI/180.f);
+	m_StrapOffset = m_Offset;
+	if (pSettings->line_exist(section, "strap_position") && pSettings->line_exist(section, "strap_orientation")) {
+		Fvector				pos, ypr;
+		pos = pSettings->r_fvector3(section, "strap_position");
+		ypr = pSettings->r_fvector3(section, "strap_orientation");
+		ypr.mul(PI / 180.f);
 
-		m_StrapOffset.setHPB			(ypr.x,ypr.y,ypr.z);
-		m_StrapOffset.translate_over	(pos);
+		m_StrapOffset.setHPB(ypr.x, ypr.y, ypr.z);
+		m_StrapOffset.translate_over(pos);
 	}
 #endif
 
 	// load ammo classes
-	m_ammoTypes.clear	(); 
-	LPCSTR				S = pSettings->r_string(section,"ammo_class");
-	if (S && S[0]) 
+	m_ammoTypes.clear();
+	LPCSTR				S = pSettings->r_string(section, "ammo_class");
+	if (S && S[0])
 	{
 		string128		_ammoItem;
-		int				count		= _GetItemCount	(S);
-		for (int it=0; it<count; ++it)	
+		int				count = _GetItemCount(S);
+		for (int it = 0; it < count; ++it)
 		{
-			_GetItem				(S,it,_ammoItem);
-			m_ammoTypes.push_back	(_ammoItem);
+			_GetItem(S, it, _ammoItem);
+			m_ammoTypes.push_back(_ammoItem);
 		}
 	}
 
-	iAmmoElapsed		= pSettings->r_s32		(section,"ammo_elapsed"		);
-	iMagazineSize		= pSettings->r_s32		(section,"ammo_mag_size"	);
-	
+	iAmmoElapsed = pSettings->r_s32(section, "ammo_elapsed");
+	iMagazineSize = pSettings->r_s32(section, "ammo_mag_size");
+
 	////////////////////////////////////////////////////
 	// дисперсия стрельбы
 
 	//подбрасывание камеры во время отдачи
-	camMaxAngle			= pSettings->r_float		(section,"cam_max_angle"	); 
-	camMaxAngle			= deg2rad					(camMaxAngle);
-	camRelaxSpeed		= pSettings->r_float		(section,"cam_relax_speed"	); 
-	camRelaxSpeed		= deg2rad					(camRelaxSpeed);
+	camMaxAngle = pSettings->r_float(section, "cam_max_angle");
+	camMaxAngle = deg2rad(camMaxAngle);
+	camRelaxSpeed = pSettings->r_float(section, "cam_relax_speed");
+	camRelaxSpeed = deg2rad(camRelaxSpeed);
 	if (pSettings->line_exist(section, "cam_relax_speed_ai"))
 	{
-		camRelaxSpeed_AI		= pSettings->r_float		(section,"cam_relax_speed_ai"	); 
-		camRelaxSpeed_AI		= deg2rad					(camRelaxSpeed_AI);
+		camRelaxSpeed_AI = pSettings->r_float(section, "cam_relax_speed_ai");
+		camRelaxSpeed_AI = deg2rad(camRelaxSpeed_AI);
 	}
 	else
 	{
-		camRelaxSpeed_AI	= camRelaxSpeed;
+		camRelaxSpeed_AI = camRelaxSpeed;
 	}
-	
-//	camDispersion		= pSettings->r_float		(section,"cam_dispersion"	); 
-//	camDispersion		= deg2rad					(camDispersion);
 
-	camMaxAngleHorz		= pSettings->r_float		(section,"cam_max_angle_horz"	); 
-	camMaxAngleHorz		= deg2rad					(camMaxAngleHorz);
-	camStepAngleHorz	= pSettings->r_float		(section,"cam_step_angle_horz"	); 
-	camStepAngleHorz	= deg2rad					(camStepAngleHorz);	
-	camDispertionFrac			= READ_IF_EXISTS(pSettings, r_float, section, "cam_dispertion_frac",	0.7f);
+	//	camDispersion		= pSettings->r_float		(section,"cam_dispersion"	); 
+	//	camDispersion		= deg2rad					(camDispersion);
+
+	camMaxAngleHorz = pSettings->r_float(section, "cam_max_angle_horz");
+	camMaxAngleHorz = deg2rad(camMaxAngleHorz);
+	camStepAngleHorz = pSettings->r_float(section, "cam_step_angle_horz");
+	camStepAngleHorz = deg2rad(camStepAngleHorz);
+	camDispertionFrac = READ_IF_EXISTS(pSettings, r_float, section, "cam_dispertion_frac", 0.7f);
 	//  [8/2/2005]
 	//m_fParentDispersionModifier = READ_IF_EXISTS(pSettings, r_float, section, "parent_dispersion_modifier",1.0f);
-	m_fPDM_disp_base			= READ_IF_EXISTS(pSettings, r_float, section, "PDM_disp_base",	1.0f);
-	m_fPDM_disp_vel_factor		= READ_IF_EXISTS(pSettings, r_float, section, "PDM_disp_vel_factor",	1.0f);
-	m_fPDM_disp_accel_factor	= READ_IF_EXISTS(pSettings, r_float, section, "PDM_disp_accel_factor",	1.0f);
-	m_fPDM_disp_crouch			= READ_IF_EXISTS(pSettings, r_float, section, "PDM_disp_crouch",	1.0f);
-	m_fPDM_disp_crouch_no_acc	= READ_IF_EXISTS(pSettings, r_float, section, "PDM_disp_crouch_no_acc",	1.0f);
+	m_fPDM_disp_base = READ_IF_EXISTS(pSettings, r_float, section, "PDM_disp_base", 1.0f);
+	m_fPDM_disp_vel_factor = READ_IF_EXISTS(pSettings, r_float, section, "PDM_disp_vel_factor", 1.0f);
+	m_fPDM_disp_accel_factor = READ_IF_EXISTS(pSettings, r_float, section, "PDM_disp_accel_factor", 1.0f);
+	m_fPDM_disp_crouch = READ_IF_EXISTS(pSettings, r_float, section, "PDM_disp_crouch", 1.0f);
+	m_fPDM_disp_crouch_no_acc = READ_IF_EXISTS(pSettings, r_float, section, "PDM_disp_crouch_no_acc", 1.0f);
 	//  [8/2/2005]
 
-	fireDispersionConditionFactor = pSettings->r_float(section,"fire_dispersion_condition_factor"); 
-	misfireProbability			  = pSettings->r_float(section,"misfire_probability"); 
-	misfireConditionK			  = READ_IF_EXISTS(pSettings, r_float, section, "misfire_condition_k",	1.0f);
-	conditionDecreasePerShot	  = pSettings->r_float(section,"condition_shot_dec"); 
-	conditionDecreasePerShotOnHit = READ_IF_EXISTS( pSettings, r_float, section, "condition_shot_dec_on_hit", 0.f );
-	conditionDecreasePerShotSilencer = READ_IF_EXISTS( pSettings, r_float, section, "condition_shot_dec_silencer", conditionDecreasePerShot );
-		
-	vLoadedFirePoint	= pSettings->r_fvector3		(section,"fire_point"		);
-	
-	if(pSettings->line_exist(section,"fire_point2")) 
-		vLoadedFirePoint2= pSettings->r_fvector3	(section,"fire_point2");
-	else 
-		vLoadedFirePoint2= vLoadedFirePoint;
+	fireDispersionConditionFactor = pSettings->r_float(section, "fire_dispersion_condition_factor");
+	misfireProbability = pSettings->r_float(section, "misfire_probability");
+	misfireConditionK = READ_IF_EXISTS(pSettings, r_float, section, "misfire_condition_k", 1.0f);
+	conditionDecreasePerShot = pSettings->r_float(section, "condition_shot_dec");
+	conditionDecreasePerShotOnHit = READ_IF_EXISTS(pSettings, r_float, section, "condition_shot_dec_on_hit", 0.f);
+	conditionDecreasePerShotSilencer = READ_IF_EXISTS(pSettings, r_float, section, "condition_shot_dec_silencer", conditionDecreasePerShot);
+
+	vLoadedFirePoint = pSettings->r_fvector3(section, "fire_point");
+
+	if (pSettings->line_exist(section, "fire_point2"))
+		vLoadedFirePoint2 = pSettings->r_fvector3(section, "fire_point2");
+	else
+		vLoadedFirePoint2 = vLoadedFirePoint;
 
 	// hands
-	eHandDependence		= EHandDependence(pSettings->r_s32(section,"hand_dependence"));
-	m_bIsSingleHanded	= true;
+	eHandDependence = EHandDependence(pSettings->r_s32(section, "hand_dependence"));
+	m_bIsSingleHanded = true;
 	if (pSettings->line_exist(section, "single_handed"))
-		m_bIsSingleHanded	= !!pSettings->r_bool(section, "single_handed");
+		m_bIsSingleHanded = !!pSettings->r_bool(section, "single_handed");
 	// 
-	m_fMinRadius		= pSettings->r_float		(section,"min_radius");
-	m_fMaxRadius		= pSettings->r_float		(section,"max_radius");
+	m_fMinRadius = pSettings->r_float(section, "min_radius");
+	m_fMaxRadius = pSettings->r_float(section, "max_radius");
 
 
 	// информация о возможных апгрейдах и их визуализации в инвентаре
-	m_eScopeStatus			 = (ALife::EWeaponAddonStatus)pSettings->r_s32(section,"scope_status");
-	m_eSilencerStatus		 = (ALife::EWeaponAddonStatus)pSettings->r_s32(section,"silencer_status");
-	m_eGrenadeLauncherStatus = (ALife::EWeaponAddonStatus)pSettings->r_s32(section,"grenade_launcher_status");
+	m_eScopeStatus = (ALife::EWeaponAddonStatus)pSettings->r_s32(section, "scope_status");
+	m_eSilencerStatus = (ALife::EWeaponAddonStatus)pSettings->r_s32(section, "silencer_status");
+	m_eGrenadeLauncherStatus = (ALife::EWeaponAddonStatus)pSettings->r_s32(section, "grenade_launcher_status");
 
-	m_bZoomEnabled = !!pSettings->r_bool(section,"zoom_enabled");
+	m_bZoomEnabled = !!pSettings->r_bool(section, "zoom_enabled");
 	m_bUseScopeZoom = !!READ_IF_EXISTS(pSettings, r_bool, section, "use_scope_zoom", false);
 	m_bUseScopeGrenadeZoom = !!READ_IF_EXISTS(pSettings, r_bool, section, "use_scope_grenade_zoom", false);
 	m_bUseScopeDOF = !!READ_IF_EXISTS(pSettings, r_bool, section, "use_scope_dof", true);
@@ -363,46 +363,46 @@ void CWeapon::Load		(LPCSTR section)
 
 	m_fZoomFactor = CurrentZoomFactor();
 
-        m_allScopeNames.clear();
+	m_allScopeNames.clear();
 	m_highlightAddons.clear();
-	if(m_eScopeStatus == ALife::eAddonAttachable)
+	if (m_eScopeStatus == ALife::eAddonAttachable)
 	{
-		m_sScopeName = pSettings->r_string(section,"scope_name");
-		m_iScopeX = pSettings->r_s32(section,"scope_x");
-		m_iScopeY = pSettings->r_s32(section,"scope_y");
+		m_sScopeName = pSettings->r_string(section, "scope_name");
+		m_iScopeX = pSettings->r_s32(section, "scope_x");
+		m_iScopeY = pSettings->r_s32(section, "scope_y");
 
-                m_allScopeNames.push_back( m_sScopeName );
-                if ( pSettings->line_exist( section, "scope_names" ) ) {
-                  LPCSTR S = pSettings->r_string( section, "scope_names" );
-                  if ( S && S[ 0 ] ) {
-                    string128 _scopeItem;
-                    int count = _GetItemCount( S );
-                    for ( int it = 0; it < count; ++it ) {
-                      _GetItem( S, it, _scopeItem );
-                      m_allScopeNames.push_back( _scopeItem );
-                      m_highlightAddons.push_back( _scopeItem );
-                    }
-                  }
-                }
+		m_allScopeNames.push_back(m_sScopeName);
+		if (pSettings->line_exist(section, "scope_names")) {
+			LPCSTR S = pSettings->r_string(section, "scope_names");
+			if (S && S[0]) {
+				string128 _scopeItem;
+				int count = _GetItemCount(S);
+				for (int it = 0; it < count; ++it) {
+					_GetItem(S, it, _scopeItem);
+					m_allScopeNames.push_back(_scopeItem);
+					m_highlightAddons.push_back(_scopeItem);
+				}
+			}
+		}
 	}
 
-	if(m_eSilencerStatus == ALife::eAddonAttachable)
+	if (m_eSilencerStatus == ALife::eAddonAttachable)
 	{
-		m_sSilencerName = pSettings->r_string(section,"silencer_name");
-		m_iSilencerX = pSettings->r_s32(section,"silencer_x");
-		m_iSilencerY = pSettings->r_s32(section,"silencer_y");
+		m_sSilencerName = pSettings->r_string(section, "silencer_name");
+		m_iSilencerX = pSettings->r_s32(section, "silencer_x");
+		m_iSilencerY = pSettings->r_s32(section, "silencer_y");
 	}
 
-	if(m_eGrenadeLauncherStatus == ALife::eAddonAttachable)
+	if (m_eGrenadeLauncherStatus == ALife::eAddonAttachable)
 	{
-		m_sGrenadeLauncherName = pSettings->r_string(section,"grenade_launcher_name");
-		m_iGrenadeLauncherX = pSettings->r_s32(section,"grenade_launcher_x");
-		m_iGrenadeLauncherY = pSettings->r_s32(section,"grenade_launcher_y");
+		m_sGrenadeLauncherName = pSettings->r_string(section, "grenade_launcher_name");
+		m_iGrenadeLauncherX = pSettings->r_s32(section, "grenade_launcher_x");
+		m_iGrenadeLauncherY = pSettings->r_s32(section, "grenade_launcher_y");
 	}
 
 
 	// Кости мировой модели оружия
-	m_sWpn_scope_bone    = READ_IF_EXISTS(pSettings, r_string, section, "scope_bone", wpn_scope_def_bone);
+	m_sWpn_scope_bone = READ_IF_EXISTS(pSettings, r_string, section, "scope_bone", wpn_scope_def_bone);
 	m_sWpn_silencer_bone = READ_IF_EXISTS(pSettings, r_string, section, "silencer_bone", wpn_silencer_def_bone);
 	m_sWpn_launcher_bone = READ_IF_EXISTS(pSettings, r_string, section, "launcher_bone", wpn_launcher_def_bone_shoc);
 
@@ -422,7 +422,7 @@ void CWeapon::Load		(LPCSTR section)
 	}
 
 	// Кости худовой модели оружия - если не прописаны, используются имена из конфига мировой модели.
-	m_sHud_wpn_scope_bone    = READ_IF_EXISTS(pSettings, r_string, hud_sect, "scope_bone", m_sWpn_scope_bone);
+	m_sHud_wpn_scope_bone = READ_IF_EXISTS(pSettings, r_string, hud_sect, "scope_bone", m_sWpn_scope_bone);
 	m_sHud_wpn_silencer_bone = READ_IF_EXISTS(pSettings, r_string, hud_sect, "silencer_bone", m_sWpn_silencer_bone);
 	m_sHud_wpn_launcher_bone = READ_IF_EXISTS(pSettings, r_string, hud_sect, "launcher_bone", m_sWpn_launcher_bone);
 
@@ -453,7 +453,7 @@ void CWeapon::Load		(LPCSTR section)
 	InitAddons();
 
 	m_bHideCrosshairInZoom = true;
-	if(pSettings->line_exist(hud_sect, "zoom_hide_crosshair"))
+	if (pSettings->line_exist(hud_sect, "zoom_hide_crosshair"))
 		m_bHideCrosshairInZoom = !!pSettings->r_bool(hud_sect, "zoom_hide_crosshair");
 
 	m_bZoomInertionAllow = READ_IF_EXISTS(pSettings, r_bool, hud_sect, "allow_zoom_inertion", READ_IF_EXISTS(pSettings, r_bool, "features", "default_allow_zoom_inertion", true));
@@ -465,11 +465,11 @@ void CWeapon::Load		(LPCSTR section)
 	m_u8TracerColorID = READ_IF_EXISTS(pSettings, r_u8, section, "tracers_color_ID", u8(-1));
 
 	string256						temp;
-	for (int i=egdNovice; i<egdCount; ++i) {
-		strconcat					(sizeof(temp),temp,"hit_probability_",get_token_name(difficulty_type_token,i));
-		m_hit_probability[i]		= READ_IF_EXISTS(pSettings,r_float,section,temp,1.f);
+	for (int i = egdNovice; i < egdCount; ++i) {
+		strconcat(sizeof(temp), temp, "hit_probability_", get_token_name(difficulty_type_token, i));
+		m_hit_probability[i] = READ_IF_EXISTS(pSettings, r_float, section, temp, 1.f);
 	}
-	
+
 	if (pSettings->line_exist(section, "highlight_addons")) {
 		LPCSTR S = pSettings->r_string(section, "highlight_addons");
 		if (S && S[0]) {
@@ -512,27 +512,43 @@ void CWeapon::Load		(LPCSTR section)
 	m_strafe_offset[0][1] = READ_IF_EXISTS(pSettings, r_fvector3, section, xr_strconcat(val_name, "strafe_aim_hud_offset_pos", _prefix), Fvector().set(0.005f, 0.f, 0.f));
 	m_strafe_offset[1][1] = READ_IF_EXISTS(pSettings, r_fvector3, section, xr_strconcat(val_name, "strafe_aim_hud_offset_rot", _prefix), Fvector().set(0.f, 0.f, 2.5f));
 
+	// Смещение при движении вперёд/назад
+	m_longitudinal_offset[0] = READ_IF_EXISTS(pSettings, r_float, section, xr_strconcat(val_name, "longitudinal_hud_offset", _prefix), READ_IF_EXISTS(pSettings, r_float, "features", "default_longitudinal_hud_offset", 0.04f));
+	m_longitudinal_offset[1] = READ_IF_EXISTS(pSettings, r_float, section, xr_strconcat(val_name, "longitudinal_hud_offset_aim", _prefix), m_longitudinal_offset[0]);
+
 	// Параметры стрейфа
-	float fFullStrafeTime     = READ_IF_EXISTS(pSettings, r_float, section, "strafe_transition_time", 0.25f);
+	float fFullStrafeTime = READ_IF_EXISTS(pSettings, r_float, section, "strafe_transition_time", 0.25f);
 	float fFullStrafeTime_aim = READ_IF_EXISTS(pSettings, r_float, section, "strafe_aim_transition_time", 0.15f);
-	bool bStrafeEnabled       = READ_IF_EXISTS(pSettings, r_bool, section, "strafe_enabled", READ_IF_EXISTS(pSettings, r_bool, "features", "default_strafe_enabled", true));
-	bool bStrafeEnabled_aim   = READ_IF_EXISTS(pSettings, r_bool, section, "strafe_aim_enabled", false);
+	bool bStrafeEnabled = READ_IF_EXISTS(pSettings, r_bool, section, "strafe_enabled", READ_IF_EXISTS(pSettings, r_bool, "features", "default_strafe_enabled", true));
+	bool bStrafeEnabled_aim = READ_IF_EXISTS(pSettings, r_bool, section, "strafe_aim_enabled", false);
+
+	// Параметры движения вперёд/назад
+	float fFullLongitudinalTime = READ_IF_EXISTS(pSettings, r_float, section, "longitudinal_transition_time", 0.06f);
+	float fFullLongitudinalTime_aim = READ_IF_EXISTS(pSettings, r_float, section, "longitudinal_transition_time_aim", 0.06f);
+	bool bLongitudinalOffsetEnabled = READ_IF_EXISTS(pSettings, r_bool, section, "longitudinal_offset_enabled",
+		READ_IF_EXISTS(pSettings, r_bool, "features", "default_longitudinal_offset_enabled", false));
+	bool bLongitudinalOffsetEnabled_aim = READ_IF_EXISTS(pSettings, r_bool, section, "longitudinal_offset_aim_enabled", bLongitudinalOffsetEnabled);
 
 	m_strafe_offset[2][0].set(bStrafeEnabled, fFullStrafeTime, 0.f); // normal
 	m_strafe_offset[2][1].set(bStrafeEnabled_aim, fFullStrafeTime_aim, 0.f); // aim-GL
+
+	m_longitudinal_offset[2] = fFullLongitudinalTime;
+	m_longitudinal_offset[3] = fFullLongitudinalTime_aim;
+	m_longitudinal_offset[4] = bLongitudinalOffsetEnabled;
+	m_longitudinal_offset[5] = bLongitudinalOffsetEnabled_aim;
 	//--#SM+# End--
 	////////////////////////////////////////////
 }
 
-void CWeapon::LoadFireParams		(LPCSTR section, LPCSTR prefix)
+void CWeapon::LoadFireParams(LPCSTR section, LPCSTR prefix)
 {
-	camDispersion		= pSettings->r_float		(section,"cam_dispersion"	); 
-	camDispersion		= deg2rad					(camDispersion);
+	camDispersion = pSettings->r_float(section, "cam_dispersion");
+	camDispersion = deg2rad(camDispersion);
 
-	if (pSettings->line_exist(section,"cam_dispersion_inc"))
+	if (pSettings->line_exist(section, "cam_dispersion_inc"))
 	{
-		camDispersionInc		= pSettings->r_float		(section,"cam_dispersion_inc"	); 
-		camDispersionInc		= deg2rad					(camDispersionInc);
+		camDispersionInc = pSettings->r_float(section, "cam_dispersion_inc");
+		camDispersionInc = deg2rad(camDispersionInc);
 	}
 	else
 		camDispersionInc = 0;
@@ -540,46 +556,46 @@ void CWeapon::LoadFireParams		(LPCSTR section, LPCSTR prefix)
 	CShootingObject::LoadFireParams(section, prefix);
 }
 
-BOOL CWeapon::net_Spawn		(CSE_Abstract* DC)
+BOOL CWeapon::net_Spawn(CSE_Abstract* DC)
 {
-	BOOL bResult					= inherited::net_Spawn(DC);
-	CSE_Abstract					*e	= (CSE_Abstract*)(DC);
-	CSE_ALifeItemWeapon			    *E	= smart_cast<CSE_ALifeItemWeapon*>(e);
+	BOOL bResult = inherited::net_Spawn(DC);
+	CSE_Abstract* e = (CSE_Abstract*)(DC);
+	CSE_ALifeItemWeapon* E = smart_cast<CSE_ALifeItemWeapon*>(e);
 
 	//iAmmoCurrent					= E->a_current;
-	iAmmoElapsed					= E->a_elapsed;
-	m_flagsAddOnState				= E->m_addon_flags.get();
-	m_ammoType						= E->ammo_type;
-	SetState						(E->wpn_state);
-	SetNextState					(E->wpn_state);
+	iAmmoElapsed = E->a_elapsed;
+	m_flagsAddOnState = E->m_addon_flags.get();
+	m_ammoType = E->ammo_type;
+	SetState(E->wpn_state);
+	SetNextState(E->wpn_state);
 
-	if ( m_ammoType >= m_ammoTypes.size() ) {
-	  Msg( "! [%s]: %s: wrong m_ammoType[%u/%u]", __FUNCTION__, cName().c_str(), m_ammoType, m_ammoTypes.size() - 1 );
-	  m_ammoType = 0;
-	  auto se_obj = alife_object();
-	  if ( se_obj ) {
-	    auto W = smart_cast<CSE_ALifeItemWeapon*>( se_obj );
-	    W->ammo_type = m_ammoType;
-	  }
+	if (m_ammoType >= m_ammoTypes.size()) {
+		Msg("! [%s]: %s: wrong m_ammoType[%u/%u]", __FUNCTION__, cName().c_str(), m_ammoType, m_ammoTypes.size() - 1);
+		m_ammoType = 0;
+		auto se_obj = alife_object();
+		if (se_obj) {
+			auto W = smart_cast<CSE_ALifeItemWeapon*>(se_obj);
+			W->ammo_type = m_ammoType;
+		}
 	}
 
-	m_DefaultCartridge.Load(*m_ammoTypes[m_ammoType], u8(m_ammoType));	
-	if(iAmmoElapsed) 
+	m_DefaultCartridge.Load(*m_ammoTypes[m_ammoType], u8(m_ammoType));
+	if (iAmmoElapsed)
 	{
 		// нож автоматически заряжается двумя патронами, хотя
 		// размер магазина у него 0. Что бы зря не ругаться, проверим
 		// что в конфиге размер магазина не нулевой.
-		if ( iMagazineSize && iAmmoElapsed > iMagazineSize ) {
-		  Msg( "! [%s]: %s: wrong iAmmoElapsed[%u/%u]", __FUNCTION__, cName().c_str(), iAmmoElapsed, iMagazineSize );
-		  iAmmoElapsed = iMagazineSize;
-		  auto se_obj = alife_object();
-		  if ( se_obj ) {
-		    auto W = smart_cast<CSE_ALifeItemWeapon*>( se_obj );
-		    W->a_elapsed = iAmmoElapsed;
-		  }
+		if (iMagazineSize && iAmmoElapsed > iMagazineSize) {
+			Msg("! [%s]: %s: wrong iAmmoElapsed[%u/%u]", __FUNCTION__, cName().c_str(), iAmmoElapsed, iMagazineSize);
+			iAmmoElapsed = iMagazineSize;
+			auto se_obj = alife_object();
+			if (se_obj) {
+				auto W = smart_cast<CSE_ALifeItemWeapon*>(se_obj);
+				W->a_elapsed = iAmmoElapsed;
+			}
 		}
 		m_fCurrentCartirdgeDisp = m_DefaultCartridge.m_kDisp;
-		for(int i = 0; i < iAmmoElapsed; ++i) 
+		for (int i = 0; i < iAmmoElapsed; ++i)
 			m_magazine.push_back(m_DefaultCartridge);
 	}
 
@@ -592,221 +608,221 @@ BOOL CWeapon::net_Spawn		(CSE_Abstract* DC)
 	return bResult;
 }
 
-void CWeapon::net_Destroy	()
+void CWeapon::net_Destroy()
 {
-	inherited::net_Destroy	();
+	inherited::net_Destroy();
 
 	//удалить объекты партиклов
-	StopFlameParticles	();
-	StopFlameParticles2	();
-	StopLight			();
-	Light_Destroy		();
+	StopFlameParticles();
+	StopFlameParticles2();
+	StopLight();
+	Light_Destroy();
 
 	m_magazine.clear();
 	m_magazine.shrink_to_fit();
 }
 
 BOOL CWeapon::IsUpdating()
-{	
-	bool bIsActiveItem = m_pCurrentInventory && m_pCurrentInventory->ActiveItem()==this;
+{
+	bool bIsActiveItem = m_pCurrentInventory && m_pCurrentInventory->ActiveItem() == this;
 	return bIsActiveItem || bWorking || IsPending() || getVisible();
 }
 
 void CWeapon::net_Export(NET_Packet& P)
 {
-	inherited::net_Export	(P);
+	inherited::net_Export(P);
 
-	P.w_float_q8			(m_fCondition,0.0f,1.0f);
+	P.w_float_q8(m_fCondition, 0.0f, 1.0f);
 
-	u8 need_upd				= IsUpdating() ? 1 : 0;
-	P.w_u8					(need_upd);
-	P.w_u16					(u16(iAmmoElapsed));
-	P.w_u8					(m_flagsAddOnState);
-	P.w_u8					((u8)m_ammoType);
-	P.w_u8					((u8)GetState());
-	P.w_u8					((u8)m_bZoomMode);
+	u8 need_upd = IsUpdating() ? 1 : 0;
+	P.w_u8(need_upd);
+	P.w_u16(u16(iAmmoElapsed));
+	P.w_u8(m_flagsAddOnState);
+	P.w_u8((u8)m_ammoType);
+	P.w_u8((u8)GetState());
+	P.w_u8((u8)m_bZoomMode);
 }
 
 void CWeapon::net_Import(NET_Packet& P)
 {
-	inherited::net_Import (P);
+	inherited::net_Import(P);
 
-	P.r_float_q8			(m_fCondition,0.0f,1.0f);
+	P.r_float_q8(m_fCondition, 0.0f, 1.0f);
 
-	u8 flags				= 0;
-	P.r_u8					(flags);
+	u8 flags = 0;
+	P.r_u8(flags);
 
 	u16 ammo_elapsed = 0;
-	P.r_u16					(ammo_elapsed);
+	P.r_u16(ammo_elapsed);
 
 	u8						NewAddonState;
-	P.r_u8					(NewAddonState);
+	P.r_u8(NewAddonState);
 
-	m_flagsAddOnState		= NewAddonState;
-	UpdateAddonsVisibility	();
+	m_flagsAddOnState = NewAddonState;
+	UpdateAddonsVisibility();
 
 	u8 ammoType, wstate;
-	P.r_u8					(ammoType);
-	P.r_u8					(wstate);
+	P.r_u8(ammoType);
+	P.r_u8(wstate);
 
 	u8 Zoom;
-	P.r_u8					(Zoom);
+	P.r_u8(Zoom);
 
 	if (H_Parent() && H_Parent()->Remote())
 	{
-		if (Zoom) 
+		if (Zoom)
 			OnZoomIn();
-		else 
+		else
 			OnZoomOut();
 	};
 	switch (wstate)
-	{	
+	{
 	case eFire:
 	case eFire2:
 	case eSwitch:
 	case eReload:
-		{
-		}break;	
+	{
+	}break;
 	default:
+	{
+		if (ammoType >= m_ammoTypes.size())
+			Msg("!! Weapon [%d], State - [%d]", ID(), wstate);
+		else
 		{
-			if (ammoType >= m_ammoTypes.size())
-				Msg("!! Weapon [%d], State - [%d]", ID(), wstate);
-			else
-			{
-				m_ammoType = ammoType;
-				SetAmmoElapsed((ammo_elapsed));
-			}
-		}break;
+			m_ammoType = ammoType;
+			SetAmmoElapsed((ammo_elapsed));
+		}
+	}break;
 	}
-	
+
 	VERIFY((u32)iAmmoElapsed == m_magazine.size());
 }
 
-void CWeapon::save(NET_Packet &output_packet)
+void CWeapon::save(NET_Packet& output_packet)
 {
-	inherited::save	(output_packet);
-	save_data		(iAmmoElapsed,		output_packet);
-	save_data		(m_flagsAddOnState, output_packet);
-	save_data		(m_ammoType,		output_packet);
-	save_data		(m_bZoomMode,		output_packet);
+	inherited::save(output_packet);
+	save_data(iAmmoElapsed, output_packet);
+	save_data(m_flagsAddOnState, output_packet);
+	save_data(m_ammoType, output_packet);
+	save_data(m_bZoomMode, output_packet);
 }
 
-void CWeapon::load(IReader &input_packet)
+void CWeapon::load(IReader& input_packet)
 {
-	inherited::load	(input_packet);
-	load_data		(iAmmoElapsed,		input_packet);
-	load_data		(m_flagsAddOnState, input_packet);
-	UpdateAddonsVisibility	();
-	load_data		(m_ammoType,		input_packet);
-	load_data		(m_bZoomMode,		input_packet);
+	inherited::load(input_packet);
+	load_data(iAmmoElapsed, input_packet);
+	load_data(m_flagsAddOnState, input_packet);
+	UpdateAddonsVisibility();
+	load_data(m_ammoType, input_packet);
+	load_data(m_bZoomMode, input_packet);
 
 	if (m_bZoomMode)	OnZoomIn();
-		else			OnZoomOut();
+	else			OnZoomOut();
 }
 
 
-void CWeapon::OnEvent(NET_Packet& P, u16 type) 
+void CWeapon::OnEvent(NET_Packet& P, u16 type)
 {
 	switch (type)
 	{
 	case GE_ADDON_CHANGE:
-		{
-			P.r_u8					(m_flagsAddOnState);
-			InitAddons();
-			UpdateAddonsVisibility();
-		}break;
+	{
+		P.r_u8(m_flagsAddOnState);
+		InitAddons();
+		UpdateAddonsVisibility();
+	}break;
 
 	case GE_WPN_STATE_CHANGE:
-		{
-			u8				state;
-			P.r_u8			(state);
-			P.r_u8			(m_sub_state);		
-//			u8 NewAmmoType = 
-				P.r_u8();
-			u8 AmmoElapsed = P.r_u8();
-			u8 NextAmmo = P.r_u8();
-			if (NextAmmo == u8(-1))
-				m_set_next_ammoType_on_reload = u32(-1);
-			else
-				m_set_next_ammoType_on_reload = u8(NextAmmo);
+	{
+		u8				state;
+		P.r_u8(state);
+		P.r_u8(m_sub_state);
+		//			u8 NewAmmoType = 
+		P.r_u8();
+		u8 AmmoElapsed = P.r_u8();
+		u8 NextAmmo = P.r_u8();
+		if (NextAmmo == u8(-1))
+			m_set_next_ammoType_on_reload = u32(-1);
+		else
+			m_set_next_ammoType_on_reload = u8(NextAmmo);
 
-			if (OnClient())
-				SetAmmoElapsed(int(AmmoElapsed));			
-			OnStateSwitch(u32(state), GetState());
-		}
-		break;
+		if (OnClient())
+			SetAmmoElapsed(int(AmmoElapsed));
+		OnStateSwitch(u32(state), GetState());
+	}
+	break;
 	default:
-		{
-			inherited::OnEvent(P,type);
-		}break;
+	{
+		inherited::OnEvent(P, type);
+	}break;
 	}
 };
 
-void CWeapon::shedule_Update	(u32 dT)
+void CWeapon::shedule_Update(u32 dT)
 {
 	// Queue shrink
 //	u32	dwTimeCL		= Level().timeServer()-NET_Latency;
 //	while ((NET.size()>2) && (NET[1].dwTimeStamp<dwTimeCL)) NET.pop_front();	
 
 	// Inherited
-	inherited::shedule_Update	(dT);
+	inherited::shedule_Update(dT);
 }
 
-void CWeapon::OnH_B_Independent	(bool just_before_destroy)
+void CWeapon::OnH_B_Independent(bool just_before_destroy)
 {
-	RemoveShotEffector			();
+	RemoveShotEffector();
 
 	inherited::OnH_B_Independent(just_before_destroy);
 
 	//завершить принудительно все процессы что шли
-	FireEnd						();
-	SetPending					(FALSE);
-	SwitchState					(eIdle);
+	FireEnd();
+	SetPending(FALSE);
+	SwitchState(eIdle);
 
-	m_strapped_mode				= false;
-	OnZoomOut					();
-	m_fZoomRotationFactor	= 0.f;
-	UpdateXForm					();
+	m_strapped_mode = false;
+	OnZoomOut();
+	m_fZoomRotationFactor = 0.f;
+	UpdateXForm();
 
 	m_nearwall_last_hud_fov = psHUD_FOV_def;
 }
 
-void CWeapon::OnH_A_Independent	()
+void CWeapon::OnH_A_Independent()
 {
 	inherited::OnH_A_Independent();
-	Light_Destroy				();
+	Light_Destroy();
 };
 
-void CWeapon::OnH_A_Chield		()
+void CWeapon::OnH_A_Chield()
 {
-	inherited::OnH_A_Chield		();
+	inherited::OnH_A_Chield();
 
-	UpdateAddonsVisibility		();
+	UpdateAddonsVisibility();
 };
 
-void CWeapon::OnActiveItem ()
+void CWeapon::OnActiveItem()
 {
-	inherited::OnActiveItem		();
+	inherited::OnActiveItem();
 	//если мы занружаемся и оружие было в руках
-	SetState					(eIdle);
-	SetNextState				(eIdle);
+	SetState(eIdle);
+	SetNextState(eIdle);
 }
 
-void CWeapon::OnHiddenItem ()
+void CWeapon::OnHiddenItem()
 {
 	inherited::OnHiddenItem();
-	SetState					(eHidden);
-	SetNextState				(eHidden);
-	m_set_next_ammoType_on_reload	= u32(-1);
+	SetState(eHidden);
+	SetNextState(eHidden);
+	m_set_next_ammoType_on_reload = u32(-1);
 }
 
 
-void CWeapon::OnH_B_Chield		()
+void CWeapon::OnH_B_Chield()
 {
-	inherited::OnH_B_Chield		();
+	inherited::OnH_B_Chield();
 
-	OnZoomOut					();
-	m_set_next_ammoType_on_reload	= u32(-1);
+	OnZoomOut();
+	m_set_next_ammoType_on_reload = u32(-1);
 
 	m_nearwall_last_hud_fov = psHUD_FOV_def;
 }
@@ -847,7 +863,7 @@ void CWeapon::UpdateWeaponParams()
 			if (w_timers.z > EPS)		// оружие все еще нагрето
 			{
 				float tm = state_time_heat + previous_heating - Device.fTimeGlobal;
-				w_timers.z = (tm<EPS) ? 0.f : tm;
+				w_timers.z = (tm < EPS) ? 0.f : tm;
 			}
 		}
 		w_timers.x = Device.fTimeGlobal - state_time;		// обновляем таймер текущего состояния
@@ -870,181 +886,182 @@ u8 CWeapon::idle_state() {
 }
 
 
-void CWeapon::UpdateCL		()
+void CWeapon::UpdateCL()
 {
-	inherited::UpdateCL		();
+	inherited::UpdateCL();
 
 	UpdateHUDAddonsVisibility();
 
 	//подсветка от выстрела
-	UpdateLight				();
+	UpdateLight();
 
 	if (ParentIsActor())
 		UpdateWeaponParams();	// параметры для рендера оружия в режиме тепловидения
 
 	//нарисовать партиклы
-	UpdateFlameParticles	();
-	UpdateFlameParticles2	();
-	
+	UpdateFlameParticles();
+	UpdateFlameParticles2();
+
 	VERIFY(smart_cast<IKinematics*>(Visual()));
 
-        if ( GetState() == eIdle ) {
-          auto state = idle_state();
-          if ( m_idle_state != state ) {
-            m_idle_state = state;
+	if (GetState() == eIdle) {
+		auto state = idle_state();
+		if (m_idle_state != state) {
+			m_idle_state = state;
 			if (GetNextState() != eMagEmpty && GetNextState() != eReload)
 			{
 				SwitchState(eIdle);
 			}
-          }
-        }
-        else
-          m_idle_state = eIdle;
+		}
+	}
+	else
+		m_idle_state = eIdle;
 }
 
 
-void CWeapon::renderable_Render		()
+void CWeapon::renderable_Render()
 {
-	UpdateXForm				();
+	UpdateXForm();
 
 	//нарисовать подсветку
-	RenderLight				();	
+	RenderLight();
 
 	//если мы в режиме снайперки, то сам HUD рисовать не надо
-	if(IsZoomed() && !IsRotatingToZoom() && ZoomTexture())
+	if (IsZoomed() && !IsRotatingToZoom() && ZoomTexture())
 		RenderHud(FALSE);
 	else
 		RenderHud(TRUE);
 
-	inherited::renderable_Render		();
+	inherited::renderable_Render();
 }
 
-bool CWeapon::need_renderable() 
+bool CWeapon::need_renderable()
 {
 	return !Device.m_SecondViewport.IsSVPFrame() && !(IsZoomed() && ZoomTexture() && !IsRotatingToZoom());
 }
 
 bool CWeapon::MovingAnimAllowedNow()
-{ 
-	return !IsZoomed(); 
+{
+	return !IsZoomed();
 }
 
 void CWeapon::signal_HideComplete()
 {
-	if(H_Parent())
+	if (H_Parent())
 		setVisible(FALSE);
 	SetPending(FALSE);
 }
 
 void CWeapon::SetDefaults()
 {
-	bWorking2			= false;
-	SetPending			(FALSE);
+	bWorking2 = false;
+	SetPending(FALSE);
 
-	m_flags.set			(FUsingCondition, TRUE);
-	bMisfire			= false;
-	m_flagsAddOnState	= 0;
-	m_bZoomMode			= false;
+	m_flags.set(FUsingCondition, TRUE);
+	bMisfire = false;
+	m_flagsAddOnState = 0;
+	m_bZoomMode = false;
 }
 
 void CWeapon::UpdatePosition(const Fmatrix& trans)
 {
-	Position().set		(trans.c);
-	XFORM().mul			(trans,m_strapped_mode ? m_StrapOffset : m_Offset);
-	VERIFY				(!fis_zero(DET(renderable.xform)));
+	Position().set(trans.c);
+	XFORM().mul(trans, m_strapped_mode ? m_StrapOffset : m_Offset);
+	VERIFY(!fis_zero(DET(renderable.xform)));
 }
 
 
-bool CWeapon::Action(s32 cmd, u32 flags) 
+bool CWeapon::Action(s32 cmd, u32 flags)
 {
-	if(inherited::Action(cmd, flags)) return true;
+	if (inherited::Action(cmd, flags)) return true;
 
-	
-	switch(cmd) 
+
+	switch (cmd)
 	{
-		case kWPN_FIRE: 
-			{
-				//если оружие чем-то занято, то ничего не делать
-				{				
-					if(flags&CMD_START) 
-					{
-						if(IsPending())		return false;
-						FireStart			();
-					}else 
-						FireEnd();
-				};
-
-			} 
-			return true;
-		case kWPN_NEXT: 
-			{
-				if(IsPending() || OnClient()) 
-				{
-					return false;
-				}
-									
-				if ( Core.Features.test(xrCore::Feature::lock_reload_in_sprint) && ParentIsActor() && g_actor->get_state() & mcSprint )
-				  return true;
-
-				if(flags&CMD_START) 
-				{
-					u32 l_newType = m_ammoType;
-					bool b1, b2;
-					do
-					{
-						l_newType = (l_newType + 1) % m_ammoTypes.size();
-						b1 = l_newType != m_ammoType;
-						b2 = unlimited_ammo() ? false : (!m_pCurrentInventory->GetAmmo(*m_ammoTypes[l_newType], ParentIsActor()));
-					} while (b1 && b2);
-
-					if (l_newType != m_ammoType)
-					{
-						m_set_next_ammoType_on_reload = l_newType;
-						if (OnServer()) Reload();
-					}
-				}
-			} 
-            return true;
-
-		case kWPN_ZOOM:
+	case kWPN_FIRE:
+	{
+		//если оружие чем-то занято, то ничего не делать
 		{
-			if (IsZoomEnabled())
+			if (flags & CMD_START)
 			{
-				if (flags & CMD_START && !IsPending())
-				{
-					if (psActorFlags.is(AF_WPN_AIM_TOGGLE) && IsZoomed())
-					{
-						OnZoomOut();
-					}
-					else
-						OnZoomIn();
-				}
-				else if (IsZoomed() && !psActorFlags.is(AF_WPN_AIM_TOGGLE))
+				if (IsPending())		return false;
+				FireStart();
+			}
+			else
+				FireEnd();
+		};
+
+	}
+	return true;
+	case kWPN_NEXT:
+	{
+		if (IsPending() || OnClient())
+		{
+			return false;
+		}
+
+		if (Core.Features.test(xrCore::Feature::lock_reload_in_sprint) && ParentIsActor() && g_actor->get_state() & mcSprint)
+			return true;
+
+		if (flags & CMD_START)
+		{
+			u32 l_newType = m_ammoType;
+			bool b1, b2;
+			do
+			{
+				l_newType = (l_newType + 1) % m_ammoTypes.size();
+				b1 = l_newType != m_ammoType;
+				b2 = unlimited_ammo() ? false : (!m_pCurrentInventory->GetAmmo(*m_ammoTypes[l_newType], ParentIsActor()));
+			} while (b1 && b2);
+
+			if (l_newType != m_ammoType)
+			{
+				m_set_next_ammoType_on_reload = l_newType;
+				if (OnServer()) Reload();
+			}
+		}
+	}
+	return true;
+
+	case kWPN_ZOOM:
+	{
+		if (IsZoomEnabled())
+		{
+			if (flags & CMD_START && !IsPending())
+			{
+				if (psActorFlags.is(AF_WPN_AIM_TOGGLE) && IsZoomed())
 				{
 					OnZoomOut();
 				}
-				return true;
+				else
+					OnZoomIn();
 			}
-			else
-				return false;
-		}
-
-		case kWPN_ZOOM_INC:
-		case kWPN_ZOOM_DEC:
-		{
-			if (IsZoomEnabled() && IsZoomed() && m_bScopeDynamicZoom && IsScopeAttached() && (flags&CMD_START))
+			else if (IsZoomed() && !psActorFlags.is(AF_WPN_AIM_TOGGLE))
 			{
-				// если в режиме ПГ - не будем давать использовать динамический зум
-				if (IsGrenadeMode())
-					return false;
-
-				ZoomChange(cmd == kWPN_ZOOM_INC);
-
-				return true;
+				OnZoomOut();
 			}
-			else
-				return false;
+			return true;
 		}
+		else
+			return false;
+	}
+
+	case kWPN_ZOOM_INC:
+	case kWPN_ZOOM_DEC:
+	{
+		if (IsZoomEnabled() && IsZoomed() && m_bScopeDynamicZoom && IsScopeAttached() && (flags & CMD_START))
+		{
+			// если в режиме ПГ - не будем давать использовать динамический зум
+			if (IsGrenadeMode())
+				return false;
+
+			ZoomChange(cmd == kWPN_ZOOM_INC);
+
+			return true;
+		}
+		else
+			return false;
+	}
 	}
 	return false;
 }
@@ -1052,10 +1069,10 @@ bool CWeapon::Action(s32 cmd, u32 flags)
 void CWeapon::GetZoomData(const float scope_factor, float& delta, float& min_zoom_factor)
 {
 	float def_fov = Core.Features.test(xrCore::Feature::ogse_wpn_zoom_system) ? 1.f : g_fov;
-	float delta_factor_total = def_fov-scope_factor;
-	VERIFY(delta_factor_total>0);
-	min_zoom_factor = def_fov-delta_factor_total*m_fMinZoomK;
-	delta = (delta_factor_total*(1-m_fMinZoomK) )/m_fZoomStepCount;
+	float delta_factor_total = def_fov - scope_factor;
+	VERIFY(delta_factor_total > 0);
+	min_zoom_factor = def_fov - delta_factor_total * m_fMinZoomK;
+	delta = (delta_factor_total * (1 - m_fMinZoomK)) / m_fZoomStepCount;
 }
 
 void CWeapon::ZoomChange(bool inc)
@@ -1108,72 +1125,72 @@ void CWeapon::ZoomChange(bool inc)
 	}
 }
 
-void CWeapon::SpawnAmmo(u32 boxCurr, LPCSTR ammoSect, u32 ParentID) 
+void CWeapon::SpawnAmmo(u32 boxCurr, LPCSTR ammoSect, u32 ParentID)
 {
-	if(!m_ammoTypes.size())			return;
+	if (!m_ammoTypes.size())			return;
 	if (OnClient())					return;
-	
+
 	if (!ammoSect) ammoSect = m_ammoTypes.front().c_str();
-	
-	CSE_Abstract *D					= F_entity_Create(ammoSect);
 
-	if (D->m_tClassID==CLSID_OBJECT_AMMO	||
-		D->m_tClassID==CLSID_OBJECT_A_M209	||
-		D->m_tClassID==CLSID_OBJECT_A_VOG25	||
-		D->m_tClassID==CLSID_OBJECT_A_OG7B)
-	{	
-		CSE_ALifeItemAmmo *l_pA		= smart_cast<CSE_ALifeItemAmmo*>(D);
-		R_ASSERT					(l_pA);
-		l_pA->m_boxSize				= (u16)pSettings->r_s32(ammoSect, "box_size");
-		D->s_name					= ammoSect;
-		D->set_name_replace			("");
-		D->s_gameid					= u8(GameID());
-		D->s_RP						= 0xff;
-		D->ID						= 0xffff;
-		if (ParentID == 0xffffffff)	
-			D->ID_Parent			= (u16)H_Parent()->ID();
+	CSE_Abstract* D = F_entity_Create(ammoSect);
+
+	if (D->m_tClassID == CLSID_OBJECT_AMMO ||
+		D->m_tClassID == CLSID_OBJECT_A_M209 ||
+		D->m_tClassID == CLSID_OBJECT_A_VOG25 ||
+		D->m_tClassID == CLSID_OBJECT_A_OG7B)
+	{
+		CSE_ALifeItemAmmo* l_pA = smart_cast<CSE_ALifeItemAmmo*>(D);
+		R_ASSERT(l_pA);
+		l_pA->m_boxSize = (u16)pSettings->r_s32(ammoSect, "box_size");
+		D->s_name = ammoSect;
+		D->set_name_replace("");
+		D->s_gameid = u8(GameID());
+		D->s_RP = 0xff;
+		D->ID = 0xffff;
+		if (ParentID == 0xffffffff)
+			D->ID_Parent = (u16)H_Parent()->ID();
 		else
-			D->ID_Parent			= (u16)ParentID;
+			D->ID_Parent = (u16)ParentID;
 
-		D->ID_Phantom				= 0xffff;
-		D->s_flags.assign			(M_SPAWN_OBJECT_LOCAL);
-		D->RespawnTime				= 0;
-		l_pA->m_tNodeID				= ai_location().level_vertex_id();
+		D->ID_Phantom = 0xffff;
+		D->s_flags.assign(M_SPAWN_OBJECT_LOCAL);
+		D->RespawnTime = 0;
+		l_pA->m_tNodeID = ai_location().level_vertex_id();
 
-		if(boxCurr == 0xffffffff) 	
-			boxCurr					= l_pA->m_boxSize;
+		if (boxCurr == 0xffffffff)
+			boxCurr = l_pA->m_boxSize;
 
-		while(boxCurr) 
+		while (boxCurr)
 		{
-			l_pA->a_elapsed			= (u16)(boxCurr > l_pA->m_boxSize ? l_pA->m_boxSize : boxCurr);
+			l_pA->a_elapsed = (u16)(boxCurr > l_pA->m_boxSize ? l_pA->m_boxSize : boxCurr);
 			NET_Packet				P;
-			D->Spawn_Write			(P, TRUE);
-			Level().Send			(P,net_flags(TRUE));
+			D->Spawn_Write(P, TRUE);
+			Level().Send(P, net_flags(TRUE));
 
-			if(boxCurr > l_pA->m_boxSize) 
-				boxCurr				-= l_pA->m_boxSize;
-			else 
-				boxCurr				= 0;
+			if (boxCurr > l_pA->m_boxSize)
+				boxCurr -= l_pA->m_boxSize;
+			else
+				boxCurr = 0;
 		}
 	};
-	F_entity_Destroy				(D);
+	F_entity_Destroy(D);
 }
 
 int CWeapon::GetAmmoCurrent(bool use_item_to_spawn) const
 {
 	int l_count = iAmmoElapsed;
-	if(!m_pCurrentInventory) return l_count;
+	if (!m_pCurrentInventory) return l_count;
 
 	//чтоб не делать лишних пересчетов
-	if(m_pCurrentInventory->ModifyFrame()<=m_dwAmmoCurrentCalcFrame)
+	if (m_pCurrentInventory->ModifyFrame() <= m_dwAmmoCurrentCalcFrame)
 		return l_count + iAmmoCurrent;
 
- 	m_dwAmmoCurrentCalcFrame = Device.dwFrame;
+	m_dwAmmoCurrentCalcFrame = Device.dwFrame;
 	iAmmoCurrent = 0;
 
-	for(int i = 0; i < (int)m_ammoTypes.size(); ++i) 
+	for (int i = 0; i < (int)m_ammoTypes.size(); ++i)
 	{
-		iAmmoCurrent += GetAmmoCount_forType( m_ammoTypes[i] );
+		iAmmoCurrent += GetAmmoCount_forType(m_ammoTypes[i]);
 
 		if (!use_item_to_spawn)
 			continue;
@@ -1186,57 +1203,57 @@ int CWeapon::GetAmmoCurrent(bool use_item_to_spawn) const
 	return l_count + iAmmoCurrent;
 }
 
-int CWeapon::GetAmmoCount( u8 ammo_type, u32 max ) const {
-  VERIFY( m_pInventory );
-  R_ASSERT( ammo_type < m_ammoTypes.size() );
+int CWeapon::GetAmmoCount(u8 ammo_type, u32 max) const {
+	VERIFY(m_pInventory);
+	R_ASSERT(ammo_type < m_ammoTypes.size());
 
-  return GetAmmoCount_forType( m_ammoTypes[ ammo_type ], max );
+	return GetAmmoCount_forType(m_ammoTypes[ammo_type], max);
 }
 
-int CWeapon::GetAmmoCount_forType( shared_str const& ammo_type, u32 max ) const {
-  u32 res = 0;
-  auto callback = [&]( const auto pIItem ) -> bool {
-    auto* ammo = smart_cast<CWeaponAmmo*>( pIItem );
-    if ( ammo->cNameSect() == ammo_type )
-      res += ammo->m_boxCurr;
-    return ( max > 0 && res >= max );
-  };
+int CWeapon::GetAmmoCount_forType(shared_str const& ammo_type, u32 max) const {
+	u32 res = 0;
+	auto callback = [&](const auto pIItem) -> bool {
+		auto* ammo = smart_cast<CWeaponAmmo*>(pIItem);
+		if (ammo->cNameSect() == ammo_type)
+			res += ammo->m_boxCurr;
+		return (max > 0 && res >= max);
+	};
 
-  m_pCurrentInventory->IterateAmmo( false, callback );
-  if ( max == 0 || res < max )
-    if ( !smart_cast<const CActor*>( H_Parent() ) || !psActorFlags.test( AF_AMMO_ON_BELT ) )
-      m_pCurrentInventory->IterateAmmo( true, callback );
+	m_pCurrentInventory->IterateAmmo(false, callback);
+	if (max == 0 || res < max)
+		if (!smart_cast<const CActor*>(H_Parent()) || !psActorFlags.test(AF_AMMO_ON_BELT))
+			m_pCurrentInventory->IterateAmmo(true, callback);
 
-  return res;
+	return res;
 }
 
 float CWeapon::GetConditionMisfireProbability() const
 {
-	if( GetCondition()>0.95f ) return 0.0f;
+	if (GetCondition() > 0.95f) return 0.0f;
 
-	float mis = misfireProbability+powf(1.f-GetCondition(), 3.f)*misfireConditionK;
-	clamp(mis,0.0f,0.99f);
+	float mis = misfireProbability + powf(1.f - GetCondition(), 3.f) * misfireConditionK;
+	clamp(mis, 0.0f, 0.99f);
 	return mis;
 }
 
-BOOL CWeapon::CheckForMisfire	()
+BOOL CWeapon::CheckForMisfire()
 {
 	if (OnClient()) return FALSE;
 
-	if ( Core.Features.test( xrCore::Feature::npc_simplified_shooting ) ) {
-	  CActor *actor = smart_cast<CActor*>( H_Parent() );
-	  if ( !actor ) return FALSE;
+	if (Core.Features.test(xrCore::Feature::npc_simplified_shooting)) {
+		CActor* actor = smart_cast<CActor*>(H_Parent());
+		if (!actor) return FALSE;
 	}
 
-	float rnd = ::Random.randF(0.f,1.f);
+	float rnd = ::Random.randF(0.f, 1.f);
 	float mp = GetConditionMisfireProbability();
-	if(rnd < mp)
+	if (rnd < mp)
 	{
 		FireEnd();
 
 		bMisfire = true;
-		SwitchState(eMisfire);		
-		
+		SwitchState(eMisfire);
+
 		return TRUE;
 	}
 	else
@@ -1246,7 +1263,7 @@ BOOL CWeapon::CheckForMisfire	()
 }
 
 BOOL CWeapon::IsMisfire() const
-{	
+{
 	return bMisfire;
 }
 void CWeapon::Reload()
@@ -1258,23 +1275,23 @@ void CWeapon::Reload()
 bool CWeapon::IsGrenadeLauncherAttached() const
 {
 	return (CSE_ALifeItemWeapon::eAddonAttachable == m_eGrenadeLauncherStatus &&
-			0 != (m_flagsAddOnState&CSE_ALifeItemWeapon::eWeaponAddonGrenadeLauncher)) || 
-			CSE_ALifeItemWeapon::eAddonPermanent == m_eGrenadeLauncherStatus;
+		0 != (m_flagsAddOnState & CSE_ALifeItemWeapon::eWeaponAddonGrenadeLauncher)) ||
+		CSE_ALifeItemWeapon::eAddonPermanent == m_eGrenadeLauncherStatus;
 }
 
 bool CWeapon::IsScopeAttached() const
 {
 	return (CSE_ALifeItemWeapon::eAddonAttachable == m_eScopeStatus &&
-			0 != (m_flagsAddOnState&CSE_ALifeItemWeapon::eWeaponAddonScope)) || 
-			CSE_ALifeItemWeapon::eAddonPermanent == m_eScopeStatus;
+		0 != (m_flagsAddOnState & CSE_ALifeItemWeapon::eWeaponAddonScope)) ||
+		CSE_ALifeItemWeapon::eAddonPermanent == m_eScopeStatus;
 
 }
 
 bool CWeapon::IsSilencerAttached() const
 {
 	return (CSE_ALifeItemWeapon::eAddonAttachable == m_eSilencerStatus &&
-			0 != (m_flagsAddOnState&CSE_ALifeItemWeapon::eWeaponAddonSilencer)) || 
-			CSE_ALifeItemWeapon::eAddonPermanent == m_eSilencerStatus;
+		0 != (m_flagsAddOnState & CSE_ALifeItemWeapon::eWeaponAddonSilencer)) ||
+		CSE_ALifeItemWeapon::eAddonPermanent == m_eSilencerStatus;
 }
 
 bool CWeapon::GrenadeLauncherAttachable() const
@@ -1316,7 +1333,7 @@ void CWeapon::UpdateHUDAddonsVisibility()
 
 	if (GrenadeLauncherAttachable())
 		HudItemData()->set_bone_visible(m_sHud_wpn_launcher_bone, IsGrenadeLauncherAttached());
-	
+
 	if (m_eGrenadeLauncherStatus == ALife::eAddonDisabled)
 		HudItemData()->set_bone_visible(m_sHud_wpn_launcher_bone, FALSE, TRUE);
 	else if (m_eGrenadeLauncherStatus == ALife::eAddonPermanent)
@@ -1422,10 +1439,10 @@ void CWeapon::UpdateAddonsVisibility()
 }
 
 
-bool CWeapon::Activate( bool now ) 
+bool CWeapon::Activate(bool now)
 {
 	UpdateAddonsVisibility();
-	return inherited::Activate( now );
+	return inherited::Activate(now);
 }
 
 void CWeapon::InitAddons()
@@ -1447,7 +1464,7 @@ void CWeapon::OnZoomIn()
 	m_bZoomMode = true;
 
 	// если в режиме ПГ - не будем давать включать динамический зум
-	if ( m_bScopeDynamicZoom && !IsGrenadeMode() && !SecondVPEnabled())
+	if (m_bScopeDynamicZoom && !IsGrenadeMode() && !SecondVPEnabled())
 		m_fZoomFactor = m_fRTZoomFactor;
 	else
 		m_fZoomFactor = CurrentZoomFactor();
@@ -1459,11 +1476,11 @@ void CWeapon::OnZoomIn()
 	else if (!m_bZoomInertionAllow)
 		AllowHudInertion(FALSE);
 
-	if(GetHUDmode())
+	if (GetHUDmode())
 		GamePersistent().SetPickableEffectorDOF(true);
 
 	CActor* pActor = smart_cast<CActor*>(H_Parent());
-	if ( pActor )
+	if (pActor)
 		pActor->callback(GameObject::eOnActorWeaponZoomIn)(lua_game_object());
 }
 
@@ -1471,13 +1488,13 @@ void CWeapon::OnZoomOut()
 {
 	m_fZoomFactor = Core.Features.test(xrCore::Feature::ogse_wpn_zoom_system) ? 1.f : g_fov;
 
-	if ( m_bZoomMode ) {
+	if (m_bZoomMode) {
 
 		m_bZoomMode = false;
 
 		CActor* pActor = smart_cast<CActor*>(H_Parent());
-		if ( pActor ) {
-			w_states.set( 0.f, 0.f, 0.f, 1.f );
+		if (pActor) {
+			w_states.set(0.f, 0.f, 0.f, 1.f);
 			pActor->callback(GameObject::eOnActorWeaponZoomOut)(lua_game_object());
 		}
 	}
@@ -1491,7 +1508,7 @@ void CWeapon::OnZoomOut()
 }
 
 bool CWeapon::UseScopeTexture() {
-	return (( GetAddonsState() & CSE_ALifeItemWeapon::eForcedNotexScope ) == 0) 
+	return ((GetAddonsState() & CSE_ALifeItemWeapon::eForcedNotexScope) == 0)
 		&& !SecondVPEnabled()
 		&& m_UIScope; // только если есть текстура прицела - для простого создания коллиматоров
 };
@@ -1508,87 +1525,87 @@ void CWeapon::SwitchState(u32 S)
 {
 	if (OnClient()) return;
 
-	SetNextState		( S );	// Very-very important line of code!!! :)
-	if (CHudItem::object().Local() && !CHudItem::object().getDestroy()/* && (S!=NEXT_STATE)*/ 
-		&& m_pCurrentInventory && OnServer())	
+	SetNextState(S);	// Very-very important line of code!!! :)
+	if (CHudItem::object().Local() && !CHudItem::object().getDestroy()/* && (S!=NEXT_STATE)*/
+		&& m_pCurrentInventory && OnServer())
 	{
 		// !!! Just single entry for given state !!!
 		NET_Packet		P;
-		CHudItem::object().u_EventGen		(P,GE_WPN_STATE_CHANGE,CHudItem::object().ID());
-		P.w_u8			(u8(S));
-		P.w_u8			(u8(m_sub_state));
-		P.w_u8			(u8(m_ammoType& 0xff));
-		P.w_u8			(u8(iAmmoElapsed & 0xff));
-		P.w_u8			(u8(m_set_next_ammoType_on_reload & 0xff));
-		CHudItem::object().u_EventSend		(P, net_flags(TRUE, TRUE, FALSE, TRUE));
+		CHudItem::object().u_EventGen(P, GE_WPN_STATE_CHANGE, CHudItem::object().ID());
+		P.w_u8(u8(S));
+		P.w_u8(u8(m_sub_state));
+		P.w_u8(u8(m_ammoType & 0xff));
+		P.w_u8(u8(iAmmoElapsed & 0xff));
+		P.w_u8(u8(m_set_next_ammoType_on_reload & 0xff));
+		CHudItem::object().u_EventSend(P, net_flags(TRUE, TRUE, FALSE, TRUE));
 	}
 }
 
-void CWeapon::OnMagazineEmpty	()
+void CWeapon::OnMagazineEmpty()
 {
 	VERIFY((u32)iAmmoElapsed == m_magazine.size());
 }
 
 
-void CWeapon::reinit			()
+void CWeapon::reinit()
 {
-	CShootingObject::reinit		();
-	CHudItemObject::reinit			();
+	CShootingObject::reinit();
+	CHudItemObject::reinit();
 }
 
-void CWeapon::reload			(LPCSTR section)
+void CWeapon::reload(LPCSTR section)
 {
-	CShootingObject::reload		(section);
-	CHudItemObject::reload			(section);
-	
-	m_can_be_strapped			= true;
-	m_strapped_mode				= false;
-	
-	if (pSettings->line_exist(section,"strap_bone0"))
-		m_strap_bone0			= pSettings->r_string(section,"strap_bone0");
+	CShootingObject::reload(section);
+	CHudItemObject::reload(section);
+
+	m_can_be_strapped = true;
+	m_strapped_mode = false;
+
+	if (pSettings->line_exist(section, "strap_bone0"))
+		m_strap_bone0 = pSettings->r_string(section, "strap_bone0");
 	else
-		m_can_be_strapped		= false;
-	
-	if (pSettings->line_exist(section,"strap_bone1"))
-		m_strap_bone1			= pSettings->r_string(section,"strap_bone1");
+		m_can_be_strapped = false;
+
+	if (pSettings->line_exist(section, "strap_bone1"))
+		m_strap_bone1 = pSettings->r_string(section, "strap_bone1");
 	else
-		m_can_be_strapped		= false;
+		m_can_be_strapped = false;
 
 	if (m_eScopeStatus == ALife::eAddonAttachable) {
-		m_addon_holder_range_modifier	= READ_IF_EXISTS(pSettings,r_float,m_sScopeName,"holder_range_modifier",m_holder_range_modifier);
-		m_addon_holder_fov_modifier		= READ_IF_EXISTS(pSettings,r_float,m_sScopeName,"holder_fov_modifier",m_holder_fov_modifier);
+		m_addon_holder_range_modifier = READ_IF_EXISTS(pSettings, r_float, m_sScopeName, "holder_range_modifier", m_holder_range_modifier);
+		m_addon_holder_fov_modifier = READ_IF_EXISTS(pSettings, r_float, m_sScopeName, "holder_fov_modifier", m_holder_fov_modifier);
 	}
 	else {
-		m_addon_holder_range_modifier	= m_holder_range_modifier;
-		m_addon_holder_fov_modifier		= m_holder_fov_modifier;
+		m_addon_holder_range_modifier = m_holder_range_modifier;
+		m_addon_holder_fov_modifier = m_holder_fov_modifier;
 	}
 
 
 	{
-		Fvector				pos,ypr;
-		pos					= pSettings->r_fvector3		(section,"position");
-		ypr					= pSettings->r_fvector3		(section,"orientation");
-		ypr.mul				(PI/180.f);
+		Fvector				pos, ypr;
+		pos = pSettings->r_fvector3(section, "position");
+		ypr = pSettings->r_fvector3(section, "orientation");
+		ypr.mul(PI / 180.f);
 
-		m_Offset.setHPB			(ypr.x,ypr.y,ypr.z);
-		m_Offset.translate_over	(pos);
+		m_Offset.setHPB(ypr.x, ypr.y, ypr.z);
+		m_Offset.translate_over(pos);
 	}
 
-	m_StrapOffset			= m_Offset;
-	if (pSettings->line_exist(section,"strap_position") && pSettings->line_exist(section,"strap_orientation")) {
-		Fvector				pos,ypr;
-		pos					= pSettings->r_fvector3		(section,"strap_position");
-		ypr					= pSettings->r_fvector3		(section,"strap_orientation");
-		ypr.mul				(PI/180.f);
+	m_StrapOffset = m_Offset;
+	if (pSettings->line_exist(section, "strap_position") && pSettings->line_exist(section, "strap_orientation")) {
+		Fvector				pos, ypr;
+		pos = pSettings->r_fvector3(section, "strap_position");
+		ypr = pSettings->r_fvector3(section, "strap_orientation");
+		ypr.mul(PI / 180.f);
 
-		m_StrapOffset.setHPB			(ypr.x,ypr.y,ypr.z);
-		m_StrapOffset.translate_over	(pos);
+		m_StrapOffset.setHPB(ypr.x, ypr.y, ypr.z);
+		m_StrapOffset.translate_over(pos);
 	}
 	else
-		m_can_be_strapped	= false;
+		m_can_be_strapped = false;
 
-	m_ef_main_weapon_type	= READ_IF_EXISTS(pSettings,r_u32,section,"ef_main_weapon_type",u32(-1));
-	m_ef_weapon_type		= READ_IF_EXISTS(pSettings,r_u32,section,"ef_weapon_type",u32(-1));
+	m_ef_main_weapon_type = READ_IF_EXISTS(pSettings, r_u32, section, "ef_main_weapon_type", u32(-1));
+	m_ef_weapon_type = READ_IF_EXISTS(pSettings, r_u32, section, "ef_weapon_type", u32(-1));
 }
 
 void CWeapon::create_physic_shell()
@@ -1606,7 +1623,7 @@ void CWeapon::setup_physic_shell()
 	CPhysicsShellHolder::setup_physic_shell();
 }
 
-bool CWeapon::can_kill	() const
+bool CWeapon::can_kill() const
 {
 	if (GetAmmoCurrent(true) || m_ammoTypes.empty())
 		return				(true);
@@ -1614,19 +1631,19 @@ bool CWeapon::can_kill	() const
 	return					(false);
 }
 
-CInventoryItem *CWeapon::can_kill	(CInventory *inventory) const
+CInventoryItem* CWeapon::can_kill(CInventory* inventory) const
 {
 	if (GetAmmoElapsed() || m_ammoTypes.empty())
 		return				(const_cast<CWeapon*>(this));
 
 	TIItemContainer::iterator I = inventory->m_all.begin();
 	TIItemContainer::iterator E = inventory->m_all.end();
-	for ( ; I != E; ++I) {
-		CInventoryItem	*inventory_item = smart_cast<CInventoryItem*>(*I);
+	for (; I != E; ++I) {
+		CInventoryItem* inventory_item = smart_cast<CInventoryItem*>(*I);
 		if (!inventory_item)
 			continue;
-		
-		xr_vector<shared_str>::const_iterator	i = std::find(m_ammoTypes.begin(),m_ammoTypes.end(),inventory_item->object().cNameSect());
+
+		xr_vector<shared_str>::const_iterator	i = std::find(m_ammoTypes.begin(), m_ammoTypes.end(), inventory_item->object().cNameSect());
 		if (i != m_ammoTypes.end())
 			return			(inventory_item);
 	}
@@ -1634,19 +1651,19 @@ CInventoryItem *CWeapon::can_kill	(CInventory *inventory) const
 	return					(0);
 }
 
-const CInventoryItem *CWeapon::can_kill	(const xr_vector<const CGameObject*> &items) const
+const CInventoryItem* CWeapon::can_kill(const xr_vector<const CGameObject*>& items) const
 {
 	if (m_ammoTypes.empty())
 		return				(this);
 
 	xr_vector<const CGameObject*>::const_iterator I = items.begin();
 	xr_vector<const CGameObject*>::const_iterator E = items.end();
-	for ( ; I != E; ++I) {
-		const CInventoryItem	*inventory_item = smart_cast<const CInventoryItem*>(*I);
+	for (; I != E; ++I) {
+		const CInventoryItem* inventory_item = smart_cast<const CInventoryItem*>(*I);
 		if (!inventory_item)
 			continue;
 
-		xr_vector<shared_str>::const_iterator	i = std::find(m_ammoTypes.begin(),m_ammoTypes.end(),inventory_item->object().cNameSect());
+		xr_vector<shared_str>::const_iterator	i = std::find(m_ammoTypes.begin(), m_ammoTypes.end(), inventory_item->object().cNameSect());
 		if (i != m_ammoTypes.end())
 			return			(inventory_item);
 	}
@@ -1654,13 +1671,13 @@ const CInventoryItem *CWeapon::can_kill	(const xr_vector<const CGameObject*> &it
 	return					(0);
 }
 
-bool CWeapon::ready_to_kill	() const
+bool CWeapon::ready_to_kill() const
 {
 	return					(
-		!IsMisfire() && 
-		((GetState() == eIdle) || (GetState() == eFire) || (GetState() == eFire2)) && 
+		!IsMisfire() &&
+		((GetState() == eIdle) || (GetState() == eFire) || (GetState() == eFire2)) &&
 		GetAmmoElapsed()
-	);
+		);
 }
 
 // Получить индекс текущих координат худа
@@ -1701,16 +1718,16 @@ u8 CWeapon::GetCurrentHudOffsetIdx()
 
 
 // Обновление координат текущего худа
-void CWeapon::UpdateHudAdditonal		(Fmatrix& trans)
+void CWeapon::UpdateHudAdditonal(Fmatrix& trans)
 {
 	auto pActor = smart_cast<const CActor*>(H_Parent());
-	if(!pActor) return;
+	if (!pActor) return;
 
 	u8 idx = GetCurrentHudOffsetIdx();
 
 	//============= Поворот ствола во время аима =============//
-	if(		(pActor->IsZoomAimingMode() && m_fZoomRotationFactor<=1.f) ||
-			(!pActor->IsZoomAimingMode() && m_fZoomRotationFactor>0.f))
+	if ((pActor->IsZoomAimingMode() && m_fZoomRotationFactor <= 1.f) ||
+		(!pActor->IsZoomAimingMode() && m_fZoomRotationFactor > 0.f))
 	{
 		attachable_hud_item* hi = HudItemData();
 		R_ASSERT(hi);
@@ -1736,13 +1753,13 @@ void CWeapon::UpdateHudAdditonal		(Fmatrix& trans)
 		hud_rotation.translate_over(curr_offs);
 		trans.mulB_43(hud_rotation);
 
-		if(pActor->IsZoomAimingMode())
+		if (pActor->IsZoomAimingMode())
 		{
-			m_fZoomRotationFactor += Device.fTimeDelta/m_fZoomRotateTime;
+			m_fZoomRotationFactor += Device.fTimeDelta / m_fZoomRotateTime;
 		}
 		else
 		{
-			m_fZoomRotationFactor -= Device.fTimeDelta/m_fZoomRotateTime;
+			m_fZoomRotationFactor -= Device.fTimeDelta / m_fZoomRotateTime;
 		}
 		clamp(m_fZoomRotationFactor, 0.f, 1.f);
 	}
@@ -1754,6 +1771,10 @@ void CWeapon::UpdateHudAdditonal		(Fmatrix& trans)
 	float fStrafeMaxTime = /*hi->m_measures.*/m_strafe_offset[2][idx].y; // Макс. время в секундах, за которое мы наклонимся из центрального положения
 	if (fStrafeMaxTime <= EPS)
 		fStrafeMaxTime = 0.01f;
+
+	float fLongitudinalMaxTime = m_longitudinal_offset[2 + idx];
+	if (fLongitudinalMaxTime <= EPS)
+		fLongitudinalMaxTime = 0.01f;
 
 	float fStepPerUpd = Device.fTimeDelta / fStrafeMaxTime; // Величина изменение фактора поворота
 
@@ -1769,7 +1790,7 @@ void CWeapon::UpdateHudAdditonal		(Fmatrix& trans)
 		m_fLR_MovingFactor += fVal;
 	}
 	else
-	{ // Двигаемся в любом другом направлении
+	{
 		if (m_fLR_MovingFactor < 0.0f)
 		{
 			m_fLR_MovingFactor += fStepPerUpd;
@@ -1781,8 +1802,34 @@ void CWeapon::UpdateHudAdditonal		(Fmatrix& trans)
 			clamp(m_fLR_MovingFactor, 0.0f, 1.0f);
 		}
 	}
+	if ((iMovingState & mcBack) != 0)
+	{
+		// Движемся назад
+		float fVal = m_fFB_MovingFactor < 0.0f ? fLongitudinalMaxTime * 3 : fLongitudinalMaxTime;
+		m_fFB_MovingFactor += fVal;
+	}
+	else if ((iMovingState & mcFwd) != 0)
+	{
+		// Движемся вперёд
+		float fVal = m_fFB_MovingFactor > 0.0f ? fLongitudinalMaxTime * 3 : fLongitudinalMaxTime;
+		m_fFB_MovingFactor -= fVal;
+	}
+	else
+	{
+		if (m_fFB_MovingFactor < 0.0f)
+		{
+			m_fFB_MovingFactor += fLongitudinalMaxTime;
+			clamp(m_fFB_MovingFactor, -1.0f, 0.0f);
+		}
+		else
+		{
+			m_fFB_MovingFactor -= fLongitudinalMaxTime;
+			clamp(m_fFB_MovingFactor, 0.0f, 1.0f);
+		}
+	}
 
 	clamp(m_fLR_MovingFactor, -1.0f, 1.0f); // Фактор боковой ходьбы не должен превышать эти лимиты
+	clamp(m_fFB_MovingFactor, -1.0f, 1.0f); // ^   *вперёд/назад*
 
 	// Производим наклон ствола для нормального режима и аима
 	for (int _idx = 0; _idx <= 1; _idx++)
@@ -1830,20 +1877,36 @@ void CWeapon::UpdateHudAdditonal		(Fmatrix& trans)
 		hud_rotation.translate_over(curr_offs);
 		trans.mulB_43(hud_rotation);
 	}
+
+	// Смещение худа при движении вперёд/назад
+	for (int i = 0; i <= 1; i++)
+	{
+		bool bEnabled = m_longitudinal_offset[4 + idx];
+		if (!bEnabled)
+			continue;
+		float curr_offs;
+		curr_offs = m_longitudinal_offset[idx];
+		curr_offs *= m_fFB_MovingFactor;
+
+		Fmatrix hud_position;
+
+		hud_position.translate(0.0f, 0.0f, curr_offs);
+		trans.mulB_43(hud_position);
+	}
 }
 
-void	CWeapon::SetAmmoElapsed	(int ammo_count)
+void	CWeapon::SetAmmoElapsed(int ammo_count)
 {
-	iAmmoElapsed				= ammo_count;
+	iAmmoElapsed = ammo_count;
 
-	u32 uAmmo					= u32(iAmmoElapsed);
+	u32 uAmmo = u32(iAmmoElapsed);
 
 	if (uAmmo != m_magazine.size())
 	{
 		if (uAmmo > m_magazine.size())
 		{
-			CCartridge			l_cartridge; 
-			l_cartridge.Load	(*m_ammoTypes[m_ammoType], u8(m_ammoType));
+			CCartridge			l_cartridge;
+			l_cartridge.Load(*m_ammoTypes[m_ammoType], u8(m_ammoType));
 			while (uAmmo > m_magazine.size())
 				m_magazine.push_back(l_cartridge);
 		}
@@ -1855,93 +1918,93 @@ void	CWeapon::SetAmmoElapsed	(int ammo_count)
 	};
 }
 
-u32	CWeapon::ef_main_weapon_type	() const
+u32	CWeapon::ef_main_weapon_type() const
 {
-	VERIFY	(m_ef_main_weapon_type != u32(-1));
+	VERIFY(m_ef_main_weapon_type != u32(-1));
 	return	(m_ef_main_weapon_type);
 }
 
-u32	CWeapon::ef_weapon_type	() const
+u32	CWeapon::ef_weapon_type() const
 {
-	VERIFY	(m_ef_weapon_type != u32(-1));
+	VERIFY(m_ef_weapon_type != u32(-1));
 	return	(m_ef_weapon_type);
 }
 
-bool CWeapon::IsNecessaryItem	    (const shared_str& item_sect)
+bool CWeapon::IsNecessaryItem(const shared_str& item_sect)
 {
-	return (std::find(m_ammoTypes.begin(), m_ammoTypes.end(), item_sect) != m_ammoTypes.end() );
+	return (std::find(m_ammoTypes.begin(), m_ammoTypes.end(), item_sect) != m_ammoTypes.end());
 }
 
-void CWeapon::modify_holder_params		(float &range, float &fov) const
+void CWeapon::modify_holder_params(float& range, float& fov) const
 {
 	if (!IsScopeAttached()) {
-		inherited::modify_holder_params	(range,fov);
+		inherited::modify_holder_params(range, fov);
 		return;
 	}
-	range	*= m_addon_holder_range_modifier;
-	fov		*= m_addon_holder_fov_modifier;
+	range *= m_addon_holder_range_modifier;
+	fov *= m_addon_holder_fov_modifier;
 }
 
 void CWeapon::OnDrawUI()
 {
-	if(IsZoomed() && ZoomHideCrosshair()){
-		if(ZoomTexture() && !IsRotatingToZoom()){
-			ZoomTexture()->SetPos	(0,0);
-			ZoomTexture()->SetRect	(0,0,UI_BASE_WIDTH, UI_BASE_HEIGHT);
-			ZoomTexture()->Render	();
+	if (IsZoomed() && ZoomHideCrosshair()) {
+		if (ZoomTexture() && !IsRotatingToZoom()) {
+			ZoomTexture()->SetPos(0, 0);
+			ZoomTexture()->SetRect(0, 0, UI_BASE_WIDTH, UI_BASE_HEIGHT);
+			ZoomTexture()->Render();
 
-//			m_UILens.Draw();
+			//			m_UILens.Draw();
 		}
 	}
 }
 
 bool CWeapon::IsHudModeNow()
-{ 
+{
 	return (HudItemData() != nullptr);
 }
 
-bool CWeapon::unlimited_ammo() 
-{ 
+bool CWeapon::unlimited_ammo()
+{
 	if (m_pCurrentInventory)
 		return inventory_owner().unlimited_ammo() && m_DefaultCartridge.m_flags.test(CCartridge::cfCanBeUnlimited);
 	else
 		return false;
 };
 
-LPCSTR	CWeapon::GetCurrentAmmo_ShortName	()
+LPCSTR	CWeapon::GetCurrentAmmo_ShortName()
 {
 	if (m_magazine.empty()) return ("");
-	CCartridge &l_cartridge = m_magazine.back();
+	CCartridge& l_cartridge = m_magazine.back();
 	return *(l_cartridge.m_InvShortName);
 }
 
 float CWeapon::GetMagazineWeight(const decltype(CWeapon::m_magazine)& mag) const
 {
-    float res = 0;
-    const char* last_type = nullptr;
-    float last_ammo_weight = 0;
-    for (auto& c : mag)
-    {
-        // Usually ammos in mag have same type, use this fact to improve performance
-        if (last_type != c.m_ammoSect.c_str())
-        {
-            last_type = c.m_ammoSect.c_str();
-            last_ammo_weight = c.Weight();
-        }
-        res += last_ammo_weight;
-    }
-    return res;
+	float res = 0;
+	const char* last_type = nullptr;
+	float last_ammo_weight = 0;
+	for (auto& c : mag)
+	{
+		// Usually ammos in mag have same type, use this fact to improve performance
+		if (last_type != c.m_ammoSect.c_str())
+		{
+			last_type = c.m_ammoSect.c_str();
+			last_ammo_weight = c.Weight();
+		}
+		res += last_ammo_weight;
+	}
+	return res;
 }
 
 float CWeapon::Weight() const
 {
 	float res = CInventoryItemObject::Weight();
-	if ( GrenadeLauncherAttachable() && IsGrenadeLauncherAttached() )
-		res += pSettings->r_float(GetGrenadeLauncherName(),"inv_weight");
-	if ( ScopeAttachable() && IsScopeAttached() )
-		res += pSettings->r_float(GetScopeName(),"inv_weight");
-	if ( SilencerAttachable() && IsSilencerAttached() )
-		res += pSettings->r_float(GetSilencerName(),"inv_weight");
+	if (GrenadeLauncherAttachable() && IsGrenadeLauncherAttached())
+		res += pSettings->r_float(GetGrenadeLauncherName(), "inv_weight");
+	if (ScopeAttachable() && IsScopeAttached())
+		res += pSettings->r_float(GetScopeName(), "inv_weight");
+	if (SilencerAttachable() && IsSilencerAttached())
+		res += pSettings->r_float(GetSilencerName(), "inv_weight");
 	res += GetMagazineWeight(m_magazine);
 
 	return res;
@@ -1950,7 +2013,7 @@ float CWeapon::Weight() const
 u32 CWeapon::Cost() const
 {
 	u32 res = m_cost;
-	
+
 	if (Core.Features.test(xrCore::Feature::wpn_cost_include_addons)) {
 		if (GrenadeLauncherAttachable() && IsGrenadeLauncherAttached())
 			res += pSettings->r_u32(GetGrenadeLauncherName(), "cost");
@@ -1991,7 +2054,7 @@ void CWeapon::Show(bool now)
 
 bool CWeapon::show_crosshair()
 {
-	return ! ( IsZoomed() && ZoomHideCrosshair() );
+	return !(IsZoomed() && ZoomHideCrosshair());
 }
 
 bool CWeapon::show_indicators()
@@ -1999,31 +2062,31 @@ bool CWeapon::show_indicators()
 	return !(IsZoomed() && (ZoomTexture() || !m_bScopeShowIndicators));
 }
 
-float CWeapon::GetConditionToShow	() const
+float CWeapon::GetConditionToShow() const
 {
 	return	(GetCondition());//powf(GetCondition(),4.0f));
 }
 
-BOOL CWeapon::ParentMayHaveAimBullet	()
+BOOL CWeapon::ParentMayHaveAimBullet()
 {
-	CObject* O=H_Parent();
+	CObject* O = H_Parent();
 	if (!O) return FALSE;
-	CEntityAlive* EA=smart_cast<CEntityAlive*>(O);
-	return EA->cast_actor()!=0;
+	CEntityAlive* EA = smart_cast<CEntityAlive*>(O);
+	return EA->cast_actor() != 0;
 }
 
-BOOL CWeapon::ParentIsActor	()
+BOOL CWeapon::ParentIsActor()
 {
-	CObject* O=H_Parent();
+	CObject* O = H_Parent();
 	if (!O) return FALSE;
-	CEntityAlive* EA=smart_cast<CEntityAlive*>(O);
+	CEntityAlive* EA = smart_cast<CEntityAlive*>(O);
 	if (!EA) return FALSE;
-	return EA->cast_actor()!=0;
+	return EA->cast_actor() != 0;
 }
 
-const float &CWeapon::hit_probability	() const
+const float& CWeapon::hit_probability() const
 {
-	VERIFY					((g_SingleGameDifficulty >= egdNovice) && (g_SingleGameDifficulty <= egdMaster)); 
+	VERIFY((g_SingleGameDifficulty >= egdNovice) && (g_SingleGameDifficulty <= egdMaster));
 	return					(m_hit_probability[egdNovice]);
 }
 
@@ -2036,14 +2099,14 @@ void CWeapon::StateSwitchCallback(GameObject::ECallbackType actor_type, GameObje
 		{
 			Actor()->callback(actor_type)(
 				lua_game_object()  // The weapon as a game object.
-			);
+				);
 		}
 		else if (smart_cast<CEntityAlive*>(H_Parent()))  // This is an NPC.
 		{
 			Actor()->callback(npc_type)(
 				smart_cast<CEntityAlive*>(H_Parent())->lua_game_object(),       // The owner of the weapon.
 				lua_game_object()                                              // The weapon itself.
-			);
+				);
 		}
 	}
 }
@@ -2069,7 +2132,7 @@ void CWeapon::UpdateSecondVP()
 }
 
 bool CWeapon::SecondVPEnabled() const
-{	
+{
 	bool bCond_2 = m_fSecondVPZoomFactor > 0.0f;     // В конфиге должен быть прописан фактор зума (scope_lense_fov_factor) больше чем 0
 	bool bCond_4 = !IsGrenadeMode();     // Мы не должны быть в режиме подствольника
 	bool bcond_6 = psActorFlags.test(AF_3D_SCOPES);
@@ -2157,16 +2220,16 @@ float CWeapon::GetHudFov()
 	}
 
 	// От бедра	 
-	return m_nearwall_last_hud_fov;
+	return m_nearwall_last_hud_fov; 
 }
 
 
 void CWeapon::OnBulletHit() {
-  if ( !fis_zero( conditionDecreasePerShotOnHit ) )
-    ChangeCondition( -conditionDecreasePerShotOnHit );
+	if (!fis_zero(conditionDecreasePerShotOnHit))
+		ChangeCondition(-conditionDecreasePerShotOnHit);
 }
 
 
 bool CWeapon::IsPartlyReloading() {
-  return ( m_set_next_ammoType_on_reload == u32(-1) && GetAmmoElapsed() > 0 && !IsMisfire() );
+	return (m_set_next_ammoType_on_reload == u32(-1) && GetAmmoElapsed() > 0 && !IsMisfire());
 }

--- a/ogsr_engine/xrGame/Weapon.cpp
+++ b/ogsr_engine/xrGame/Weapon.cpp
@@ -523,8 +523,8 @@ void CWeapon::Load(LPCSTR section)
 	bool bStrafeEnabled_aim = READ_IF_EXISTS(pSettings, r_bool, section, "strafe_aim_enabled", false);
 
 	// Параметры движения вперёд/назад
-	float fFullLongitudinalTime = READ_IF_EXISTS(pSettings, r_float, section, "longitudinal_transition_time", 0.06f);
-	float fFullLongitudinalTime_aim = READ_IF_EXISTS(pSettings, r_float, section, "longitudinal_transition_time_aim", 0.06f);
+	float fFullLongitudinalTime = READ_IF_EXISTS(pSettings, r_float, section, "longitudinal_transition_time", 0.18f);
+	float fFullLongitudinalTime_aim = READ_IF_EXISTS(pSettings, r_float, section, "longitudinal_transition_time_aim", fFullLongitudinalTime);
 	bool bLongitudinalOffsetEnabled = READ_IF_EXISTS(pSettings, r_bool, section, "longitudinal_offset_enabled",
 		READ_IF_EXISTS(pSettings, r_bool, "features", "default_longitudinal_offset_enabled", false));
 	bool bLongitudinalOffsetEnabled_aim = READ_IF_EXISTS(pSettings, r_bool, section, "longitudinal_offset_aim_enabled", bLongitudinalOffsetEnabled);
@@ -1777,6 +1777,7 @@ void CWeapon::UpdateHudAdditonal(Fmatrix& trans)
 		fLongitudinalMaxTime = 0.01f;
 
 	float fStepPerUpd = Device.fTimeDelta / fStrafeMaxTime; // Величина изменение фактора поворота
+	float fStepPerUpdLongitudinal = Device.fTimeDelta / fLongitudinalMaxTime; // ^ смещения при передвижении вперёд/назад
 
 	u32 iMovingState = pActor->MovingState();
 	if ((iMovingState & mcLStrafe) != 0)
@@ -1805,25 +1806,25 @@ void CWeapon::UpdateHudAdditonal(Fmatrix& trans)
 	if ((iMovingState & mcBack) != 0)
 	{
 		// Движемся назад
-		float fVal = m_fFB_MovingFactor < 0.0f ? fLongitudinalMaxTime * 3 : fLongitudinalMaxTime;
+		float fVal = m_fFB_MovingFactor < 0.0f ? fStepPerUpdLongitudinal * 3 : fStepPerUpdLongitudinal;
 		m_fFB_MovingFactor += fVal;
 	}
 	else if ((iMovingState & mcFwd) != 0)
 	{
 		// Движемся вперёд
-		float fVal = m_fFB_MovingFactor > 0.0f ? fLongitudinalMaxTime * 3 : fLongitudinalMaxTime;
+		float fVal = m_fFB_MovingFactor > 0.0f ? fStepPerUpdLongitudinal * 3 : fStepPerUpdLongitudinal;
 		m_fFB_MovingFactor -= fVal;
 	}
 	else
 	{
 		if (m_fFB_MovingFactor < 0.0f)
 		{
-			m_fFB_MovingFactor += fLongitudinalMaxTime;
+			m_fFB_MovingFactor += fStepPerUpdLongitudinal;
 			clamp(m_fFB_MovingFactor, -1.0f, 0.0f);
 		}
 		else
 		{
-			m_fFB_MovingFactor -= fLongitudinalMaxTime;
+			m_fFB_MovingFactor -= fStepPerUpdLongitudinal;
 			clamp(m_fFB_MovingFactor, 0.0f, 1.0f);
 		}
 	}

--- a/ogsr_engine/xrGame/Weapon.cpp
+++ b/ogsr_engine/xrGame/Weapon.cpp
@@ -1878,12 +1878,9 @@ void CWeapon::UpdateHudAdditonal		(Fmatrix& trans)
 		trans.mulB_43(hud_rotation);
 	}
 
-	// Смещение худа при движении вперёд/назад
-	for (int i = 0; i <= 1; i++)
+	bool bEnabled = m_longitudinal_offset[4 + idx];
+	if (bEnabled)
 	{
-		bool bEnabled = m_longitudinal_offset[4 + idx];
-		if (!bEnabled)
-			continue;
 		float curr_offs;
 		curr_offs = m_longitudinal_offset[idx];
 		curr_offs *= m_fFB_MovingFactor;

--- a/ogsr_engine/xrGame/Weapon.h
+++ b/ogsr_engine/xrGame/Weapon.h
@@ -29,87 +29,87 @@ constexpr float def_min_zoom_k = 0.3f;
 constexpr float def_zoom_step_count = 4.0f;
 
 class CWeapon : public CHudItemObject,
-				public CShootingObject
+	public CShootingObject
 {
 	friend class CWeaponScript;
 private:
 	typedef CHudItemObject inherited;
 
 public:
-							CWeapon				(LPCSTR name);
-	virtual					~CWeapon			();
+	CWeapon(LPCSTR name);
+	virtual					~CWeapon();
 
 	// Generic
-	virtual void			Load				(LPCSTR section);
+	virtual void			Load(LPCSTR section);
 
-	virtual BOOL			net_Spawn			(CSE_Abstract* DC);
-	virtual void			net_Destroy			();
-	virtual void			net_Export			(NET_Packet& P);
-	virtual void			net_Import			(NET_Packet& P);
-	
-	virtual CWeapon			*cast_weapon			()					{return this;}
-	virtual CWeaponMagazined*cast_weapon_magazined	()					{return 0;}
+	virtual BOOL			net_Spawn(CSE_Abstract* DC);
+	virtual void			net_Destroy();
+	virtual void			net_Export(NET_Packet& P);
+	virtual void			net_Import(NET_Packet& P);
+
+	virtual CWeapon* cast_weapon() { return this; }
+	virtual CWeaponMagazined* cast_weapon_magazined() { return 0; }
 
 
 	//serialization
-	virtual void			save				(NET_Packet &output_packet);
-	virtual void			load				(IReader &input_packet);
-	virtual BOOL			net_SaveRelevant	()								{return inherited::net_SaveRelevant();}
+	virtual void			save(NET_Packet& output_packet);
+	virtual void			load(IReader& input_packet);
+	virtual BOOL			net_SaveRelevant() { return inherited::net_SaveRelevant(); }
 
-	virtual void			UpdateCL			();
-	virtual void			shedule_Update		(u32 dt);
+	virtual void			UpdateCL();
+	virtual void			shedule_Update(u32 dt);
 
-	virtual void			renderable_Render	();
-	virtual void			OnDrawUI			();
-	virtual bool			need_renderable		();
+	virtual void			renderable_Render();
+	virtual void			OnDrawUI();
+	virtual bool			need_renderable();
 
-	virtual void			OnH_B_Chield		();
-	virtual void			OnH_A_Chield		();
-	virtual void			OnH_B_Independent	(bool just_before_destroy);
-	virtual void			OnH_A_Independent	();
-	virtual void			OnEvent				(NET_Packet& P, u16 type);// {inherited::OnEvent(P,type);}
+	virtual void			OnH_B_Chield();
+	virtual void			OnH_A_Chield();
+	virtual void			OnH_B_Independent(bool just_before_destroy);
+	virtual void			OnH_A_Independent();
+	virtual void			OnEvent(NET_Packet& P, u16 type);// {inherited::OnEvent(P,type);}
 
-	virtual	void			Hit					(SHit* pHDS);
+	virtual	void			Hit(SHit* pHDS);
 
-	virtual void			reinit				();
-	virtual void			reload				(LPCSTR section);
-	virtual void			create_physic_shell	();
+	virtual void			reinit();
+	virtual void			reload(LPCSTR section);
+	virtual void			create_physic_shell();
 	virtual void			activate_physic_shell();
-	virtual void			setup_physic_shell	();
+	virtual void			setup_physic_shell();
 
-	virtual void			SwitchState			(u32 S);
-	virtual bool			Activate( bool = false );
+	virtual void			SwitchState(u32 S);
+	virtual bool			Activate(bool = false);
 
-	virtual void			Hide( bool = false );
-	virtual void			Show( bool = false );
+	virtual void			Hide(bool = false);
+	virtual void			Show(bool = false);
 
 	//инициализация если вещь в активном слоте или спрятана на OnH_B_Chield
-	virtual void			OnActiveItem		();
-	virtual void			OnHiddenItem		();
+	virtual void			OnActiveItem();
+	virtual void			OnHiddenItem();
 
 	// Callback function added by Cribbledirge.
 	virtual IC void	StateSwitchCallback(GameObject::ECallbackType actor_type, GameObject::ECallbackType npc_type);
 
-//////////////////////////////////////////////////////////////////////////
-//  Network
-//////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////
+	//  Network
+	//////////////////////////////////////////////////////////////////////////
 
 public:
-	virtual bool			can_kill			() const;
-	virtual CInventoryItem	*can_kill			(CInventory *inventory) const;
-	virtual const CInventoryItem *can_kill		(const xr_vector<const CGameObject*> &items) const;
-	virtual bool			ready_to_kill		() const;
+	virtual bool			can_kill() const;
+	virtual CInventoryItem* can_kill(CInventory* inventory) const;
+	virtual const CInventoryItem* can_kill(const xr_vector<const CGameObject*>& items) const;
+	virtual bool			ready_to_kill() const;
 
-//////////////////////////////////////////////////////////////////////////
-//  Animation 
-//////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////
+	//  Animation 
+	//////////////////////////////////////////////////////////////////////////
 public:
 
-	void					signal_HideComplete	();
+	void					signal_HideComplete();
 
-//////////////////////////////////////////////////////////////////////////
-//  InventoryItem methods
-//////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////
+	//  InventoryItem methods
+	//////////////////////////////////////////////////////////////////////////
 public:
 	virtual bool			Action(s32 cmd, u32 flags);
 
@@ -125,28 +125,28 @@ public:
 		eMagEmpty,
 		eSwitch,
 	};
-	enum EWeaponSubStates{
-		eSubstateReloadBegin		=0,
+	enum EWeaponSubStates {
+		eSubstateReloadBegin = 0,
 		eSubstateReloadInProcess,
 		eSubstateReloadEnd,
 		eSubstateIdleMoving,
 		eSubstateIdleSprint,
 	};
 
-	virtual bool			IsHidden			()	const		{	return GetState() == eHidden;}						// Does weapon is in hidden state
-	virtual bool			IsHiding			()	const		{	return GetState() == eHiding;}
-	virtual bool			IsShowing			()	const		{	return GetState() == eShowing;}
+	virtual bool			IsHidden()	const { return GetState() == eHidden; }						// Does weapon is in hidden state
+	virtual bool			IsHiding()	const { return GetState() == eHiding; }
+	virtual bool			IsShowing()	const { return GetState() == eShowing; }
 
-	IC BOOL					IsValid				()	const		{	return iAmmoElapsed;						}
+	IC BOOL					IsValid()	const { return iAmmoElapsed; }
 	// Does weapon need's update?
-	BOOL					IsUpdating			();
+	BOOL					IsUpdating();
 
 
-	BOOL					IsMisfire			() const;
-	BOOL					CheckForMisfire		();
+	BOOL					IsMisfire() const;
+	BOOL					CheckForMisfire();
 
-	bool					IsTriStateReload	() const		{ return m_bTriStateReload;}
-	EWeaponSubStates		GetReloadState		() const		{ return (EWeaponSubStates)m_sub_state;}
+	bool					IsTriStateReload() const { return m_bTriStateReload; }
+	EWeaponSubStates		GetReloadState() const { return (EWeaponSubStates)m_sub_state; }
 	u8 idle_state();
 protected:
 	bool					m_bTriStateReload;
@@ -155,20 +155,20 @@ protected:
 	// Weapon fires now
 	bool					bWorking2;
 	// a misfire happens, you'll need to rearm weapon
-	bool					bMisfire;				
+	bool					bMisfire;
 
-//////////////////////////////////////////////////////////////////////////
-//  Weapon Addons
-//////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////
+	//  Weapon Addons
+	//////////////////////////////////////////////////////////////////////////
 public:
 	///////////////////////////////////////////
 	// работа с аддонами к оружию
 	//////////////////////////////////////////
 
 
-			bool IsGrenadeLauncherAttached	() const;
-			bool IsScopeAttached			() const;
-			bool IsSilencerAttached			() const;
+	bool IsGrenadeLauncherAttached() const;
+	bool IsScopeAttached() const;
+	bool IsSilencerAttached() const;
 
 	bool			IsGrenadeMode() const;
 
@@ -178,31 +178,31 @@ public:
 	virtual bool UseScopeTexture();
 
 	//обновление видимости для косточек аддонов
-			void UpdateAddonsVisibility();
-			void UpdateHUDAddonsVisibility();
+	void UpdateAddonsVisibility();
+	void UpdateHUDAddonsVisibility();
 	//инициализация свойств присоединенных аддонов
 	virtual void InitAddons();
 
 	//для отоброажения иконок апгрейдов в интерфейсе
-	int	GetScopeX() {return m_iScopeX;}
-	int	GetScopeY() {return m_iScopeY;}
-	int	GetSilencerX() {return m_iSilencerX;}
-	int	GetSilencerY() {return m_iSilencerY;}
-	int	GetGrenadeLauncherX() {return m_iGrenadeLauncherX;}
-	int	GetGrenadeLauncherY() {return m_iGrenadeLauncherY;}
+	int	GetScopeX() { return m_iScopeX; }
+	int	GetScopeY() { return m_iScopeY; }
+	int	GetSilencerX() { return m_iSilencerX; }
+	int	GetSilencerY() { return m_iSilencerY; }
+	int	GetGrenadeLauncherX() { return m_iGrenadeLauncherX; }
+	int	GetGrenadeLauncherY() { return m_iGrenadeLauncherY; }
 
-	const shared_str& GetGrenadeLauncherName	() const		{return m_sGrenadeLauncherName;}
-	const shared_str& GetScopeName				() const		{return m_sScopeName;}
-	const shared_str& GetSilencerName			() const		{return m_sSilencerName;}
+	const shared_str& GetGrenadeLauncherName() const { return m_sGrenadeLauncherName; }
+	const shared_str& GetScopeName() const { return m_sScopeName; }
+	const shared_str& GetSilencerName() const { return m_sSilencerName; }
 
-	u8		GetAddonsState						()		const		{return m_flagsAddOnState;};
-	void	SetAddonsState						(u8 st)	{m_flagsAddOnState=st;}//dont use!!! for buy menu only!!!
+	u8		GetAddonsState()		const { return m_flagsAddOnState; };
+	void	SetAddonsState(u8 st) { m_flagsAddOnState = st; }//dont use!!! for buy menu only!!!
 
-                                                                               //названия секций подключаемых аддонов
-    shared_str		m_sScopeName;
-    std::vector<shared_str> m_allScopeNames;
-    shared_str		m_sSilencerName;
-    shared_str		m_sGrenadeLauncherName;
+																			   //названия секций подключаемых аддонов
+	shared_str		m_sScopeName;
+	std::vector<shared_str> m_allScopeNames;
+	shared_str		m_sSilencerName;
+	shared_str		m_sGrenadeLauncherName;
 
 	shared_str m_sWpn_scope_bone;
 	shared_str m_sWpn_silencer_bone;
@@ -229,10 +229,10 @@ protected:
 	int	m_iScopeX, m_iScopeY;
 	int	m_iSilencerX, m_iSilencerY;
 	int	m_iGrenadeLauncherX, m_iGrenadeLauncherY;
-		
-///////////////////////////////////////////////////
-//	для режима приближения и снайперского прицела
-///////////////////////////////////////////////////
+
+	///////////////////////////////////////////////////
+	//	для режима приближения и снайперского прицела
+	///////////////////////////////////////////////////
 protected:
 	//разрешение регулирования приближения. Real Wolf.
 	bool			m_bScopeDynamicZoom;
@@ -245,7 +245,7 @@ protected:
 	//время приближения
 	float			m_fZoomRotateTime;
 	//текстура для снайперского прицела, в режиме приближения
-	CUIStaticItem*	m_UIScope;
+	CUIStaticItem* m_UIScope;
 	//коэффициент увеличения прицеливания
 	float			m_fIronSightZoomFactor;
 	//коэффициент увеличения прицела
@@ -268,26 +268,26 @@ protected:
 	//Целевой HUD FOV для линзы
 	float			m_fSecondVPHudFov;
 
-	bool m_bUseScopeZoom			= false;
-	bool m_bUseScopeGrenadeZoom		= false;
+	bool m_bUseScopeZoom = false;
+	bool m_bUseScopeGrenadeZoom = false;
 	bool m_bUseScopeDOF = true;
 	bool m_bForceScopeDOF = false;
 	bool m_bScopeShowIndicators = true;
 	bool m_bIgnoreScopeTexture = false;
 
-	float m_fMinZoomK			= def_min_zoom_k;
-	float m_fZoomStepCount		= def_zoom_step_count;
+	float m_fMinZoomK = def_min_zoom_k;
+	float m_fZoomStepCount = def_zoom_step_count;
 
 	float			m_fScopeInertionFactor;
 public:
 
-	IC bool					IsZoomEnabled		()	const	{return m_bZoomEnabled;}
-	void					GetZoomData			(float scope_factor, float& delta, float& min_zoom_factor);
-	virtual	void			ZoomChange			(bool inc);
-	virtual void			OnZoomIn			();
-	virtual void			OnZoomOut			();
-			bool			IsZoomed			()	const	{return m_bZoomMode;};
-	CUIStaticItem*			ZoomTexture			();	
+	IC bool					IsZoomEnabled()	const { return m_bZoomEnabled; }
+	void					GetZoomData(float scope_factor, float& delta, float& min_zoom_factor);
+	virtual	void			ZoomChange(bool inc);
+	virtual void			OnZoomIn();
+	virtual void			OnZoomOut();
+	bool			IsZoomed()	const { return m_bZoomMode; };
+	CUIStaticItem* ZoomTexture();
 	bool ZoomHideCrosshair()
 	{
 		auto* pA = smart_cast<CActor*>(H_Parent());
@@ -297,26 +297,26 @@ public:
 		return (m_bHideCrosshairInZoom || ZoomTexture()) && !psActorFlags.test(AF_CROSSHAIR_DBG);
 	}
 
-	virtual void			OnZoomChanged		() {}
+	virtual void			OnZoomChanged() {}
 
-	IC float				GetZoomFactor		() const		{	return m_fZoomFactor;	}
-	virtual	float			CurrentZoomFactor	();
+	IC float				GetZoomFactor() const { return m_fZoomFactor; }
+	virtual	float			CurrentZoomFactor();
 	//показывает, что оружие находится в соостоянии поворота для приближенного прицеливания
-			bool			IsRotatingToZoom	() const		{	return (m_fZoomRotationFactor<1.f);}
+	bool			IsRotatingToZoom() const { return (m_fZoomRotationFactor < 1.f); }
 
-	virtual float			Weight				() const;		
-	virtual u32				Cost				() const;
+	virtual float			Weight() const;
+	virtual u32				Cost() const;
 	virtual float			GetControlInertionFactor() const;
 
 public:
-    virtual EHandDependence		HandDependence		()	const		{	return eHandDependence;}
-			bool				IsSingleHanded		()	const		{	return m_bIsSingleHanded; }
+	virtual EHandDependence		HandDependence()	const { return eHandDependence; }
+	bool				IsSingleHanded()	const { return m_bIsSingleHanded; }
 
 public:
-	IC		LPCSTR			strap_bone0			() const {return m_strap_bone0;}
-	IC		LPCSTR			strap_bone1			() const {return m_strap_bone1;}
-	IC		void			strapped_mode		(bool value) {m_strapped_mode = value;}
-	IC		bool			strapped_mode		() const {return m_strapped_mode;}
+	IC		LPCSTR			strap_bone0() const { return m_strap_bone0; }
+	IC		LPCSTR			strap_bone1() const { return m_strap_bone1; }
+	IC		void			strapped_mode(bool value) { m_strapped_mode = value; }
+	IC		bool			strapped_mode() const { return m_strapped_mode; }
 
 protected:
 	LPCSTR					m_strap_bone0;
@@ -338,68 +338,70 @@ private:
 	firedeps				m_current_firedeps{};
 
 protected:
-	virtual void			UpdateFireDependencies_internal	();
-	virtual void			UpdatePosition			(const Fmatrix& transform);	//.
-	virtual void			UpdateXForm				();
+	virtual void			UpdateFireDependencies_internal();
+	virtual void			UpdatePosition(const Fmatrix& transform);	//.
+	virtual void			UpdateXForm();
 
 	float					m_fLR_MovingFactor; // !!!!
+	float					m_fFB_MovingFactor;
+	float					m_longitudinal_offset[6];
 	Fvector					m_strafe_offset[3][2]; //pos,rot,data/ normal,aim-GL --#SM+#--
 
-	virtual	u8				GetCurrentHudOffsetIdx	() override;
-	virtual bool			MovingAnimAllowedNow	();
-	virtual void			UpdateHudAdditonal		(Fmatrix&);
-	virtual bool			IsHudModeNow			();
+	virtual	u8				GetCurrentHudOffsetIdx() override;
+	virtual bool			MovingAnimAllowedNow();
+	virtual void			UpdateHudAdditonal(Fmatrix&);
+	virtual bool			IsHudModeNow();
 
-	IC		void			UpdateFireDependencies	()			{ if (dwFP_Frame==Device.dwFrame) return; UpdateFireDependencies_internal(); };
+	IC		void			UpdateFireDependencies() { if (dwFP_Frame == Device.dwFrame) return; UpdateFireDependencies_internal(); };
 
-	virtual void			LoadFireParams		(LPCSTR section, LPCSTR prefix);
-public:	
-	IC		const Fvector&	get_LastFP				()			{ UpdateFireDependencies(); return m_current_firedeps.vLastFP;	}
-	IC		const Fvector&	get_LastFP2				()			{ UpdateFireDependencies(); return m_current_firedeps.vLastFP2;	}
-	IC		const Fvector&	get_LastFD				()			{ UpdateFireDependencies(); return m_current_firedeps.vLastFD;	}
-	IC		const Fvector&	get_LastSP				()			{ UpdateFireDependencies(); return m_current_firedeps.vLastSP;	}
+	virtual void			LoadFireParams(LPCSTR section, LPCSTR prefix);
+public:
+	IC		const Fvector& get_LastFP() { UpdateFireDependencies(); return m_current_firedeps.vLastFP; }
+	IC		const Fvector& get_LastFP2() { UpdateFireDependencies(); return m_current_firedeps.vLastFP2; }
+	IC		const Fvector& get_LastFD() { UpdateFireDependencies(); return m_current_firedeps.vLastFD; }
+	IC		const Fvector& get_LastSP() { UpdateFireDependencies(); return m_current_firedeps.vLastSP; }
 
-	virtual const Fvector&	get_CurrentFirePoint	()			{ return get_LastFP();				}
-	virtual const Fvector&	get_CurrentFirePoint2	()			{ return get_LastFP2();				}
-	virtual const Fmatrix&	get_ParticlesXFORM		()			{ UpdateFireDependencies(); return m_current_firedeps.m_FireParticlesXForm;	}
+	virtual const Fvector& get_CurrentFirePoint() { return get_LastFP(); }
+	virtual const Fvector& get_CurrentFirePoint2() { return get_LastFP2(); }
+	virtual const Fmatrix& get_ParticlesXFORM() { UpdateFireDependencies(); return m_current_firedeps.m_FireParticlesXForm; }
 	virtual void			ForceUpdateFireParticles();
 
 	//////////////////////////////////////////////////////////////////////////
 	// Weapon fire
 	//////////////////////////////////////////////////////////////////////////
 protected:
-	virtual void			SetDefaults			();
+	virtual void			SetDefaults();
 
 	//трассирование полета пули
-	virtual void			FireTrace			(const Fvector& P, const Fvector& D);
-	virtual float			GetWeaponDeterioration	();
+	virtual void			FireTrace(const Fvector& P, const Fvector& D);
+	virtual float			GetWeaponDeterioration();
 
-	virtual void			FireStart			() {CShootingObject::FireStart();}
-	virtual void			FireEnd				();// {CShootingObject::FireEnd();}
+	virtual void			FireStart() { CShootingObject::FireStart(); }
+	virtual void			FireEnd();// {CShootingObject::FireEnd();}
 
-	virtual void			Fire2Start			();
-	virtual void			Fire2End			();
-	virtual void			Reload				();
-			void			StopShooting		();
-    
+	virtual void			Fire2Start();
+	virtual void			Fire2End();
+	virtual void			Reload();
+	void			StopShooting();
+
 
 	// обработка визуализации выстрела
-	virtual void			OnShot				(){};
-	virtual void			AddShotEffector		();
-	virtual void			RemoveShotEffector	();
-	virtual	void			ClearShotEffector	();
+	virtual void			OnShot() {};
+	virtual void			AddShotEffector();
+	virtual void			RemoveShotEffector();
+	virtual	void			ClearShotEffector();
 
 public:
 	//текущая дисперсия (в радианах) оружия с учетом используемого патрона
-	float					GetFireDispersion	(bool with_cartridge)			;
-	float					GetFireDispersion	(float cartridge_k)				;
-//	const Fvector&			GetRecoilDeltaAngle	();
-	virtual	int				ShotsFired			() { return 0; }
+	float					GetFireDispersion(bool with_cartridge);
+	float					GetFireDispersion(float cartridge_k);
+	//	const Fvector&			GetRecoilDeltaAngle	();
+	virtual	int				ShotsFired() { return 0; }
 
 	//параметы оружия в зависимоти от его состояния исправности
-	float					GetConditionDispersionFactor	() const;
-	float					GetConditionMisfireProbability	() const;
-	virtual	float			GetConditionToShow				() const;
+	float					GetConditionDispersionFactor() const;
+	float					GetConditionMisfireProbability() const;
+	virtual	float			GetConditionToShow() const;
 
 public:
 	//отдача при стрельбе 
@@ -425,11 +427,11 @@ protected:
 	float					conditionDecreasePerShotSilencer;
 
 	//  [8/2/2005]
-	float					m_fPDM_disp_base			;
-	float					m_fPDM_disp_vel_factor		;
-	float					m_fPDM_disp_accel_factor	;
-	float					m_fPDM_disp_crouch			;
-	float					m_fPDM_disp_crouch_no_acc	;
+	float					m_fPDM_disp_base;
+	float					m_fPDM_disp_vel_factor;
+	float					m_fPDM_disp_accel_factor;
+	float					m_fPDM_disp_crouch;
+	float					m_fPDM_disp_crouch_no_acc;
 	//  [8/2/2005]
 
 protected:
@@ -441,46 +443,46 @@ protected:
 	float					m_fMinRadius;
 	float					m_fMaxRadius;
 
-//////////////////////////////////////////////////////////////////////////
-// партиклы
-//////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////
+	// партиклы
+	//////////////////////////////////////////////////////////////////////////
 
-protected:	
+protected:
 	//для второго ствола
-			void			StartFlameParticles2();
-			void			StopFlameParticles2	();
-			void			UpdateFlameParticles2();
+	void			StartFlameParticles2();
+	void			StopFlameParticles2();
+	void			UpdateFlameParticles2();
 protected:
 	shared_str					m_sFlameParticles2;
 	//объект партиклов для стрельбы из 2-го ствола
-	CParticlesObject*		m_pFlameParticles2;
+	CParticlesObject* m_pFlameParticles2;
 
-//////////////////////////////////////////////////////////////////////////
-// Weapon and ammo
-//////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////
+	// Weapon and ammo
+	//////////////////////////////////////////////////////////////////////////
 protected:
-	int GetAmmoCount_forType( shared_str const& ammo_type, u32 = 0 ) const;
-	int GetAmmoCount( u8 ammo_type, u32 = 0 ) const;
+	int GetAmmoCount_forType(shared_str const& ammo_type, u32 = 0) const;
+	int GetAmmoCount(u8 ammo_type, u32 = 0) const;
 
 public:
-	IC int					GetAmmoElapsed		()	const		{	return /*int(m_magazine.size())*/iAmmoElapsed;}
-	IC int					GetAmmoMagSize		()	const		{	return iMagazineSize;						}
-	int						GetAmmoCurrent		(bool use_item_to_spawn = false)  const;
-	IC void					SetAmmoMagSize		(int _size) { iMagazineSize = _size; }
+	IC int					GetAmmoElapsed()	const { return /*int(m_magazine.size())*/iAmmoElapsed; }
+	IC int					GetAmmoMagSize()	const { return iMagazineSize; }
+	int						GetAmmoCurrent(bool use_item_to_spawn = false)  const;
+	IC void					SetAmmoMagSize(int _size) { iMagazineSize = _size; }
 
-	void					SetAmmoElapsed		(int ammo_count);
+	void					SetAmmoElapsed(int ammo_count);
 
-	virtual void			OnMagazineEmpty		();
-			void			SpawnAmmo			(u32 boxCurr = 0xffffffff, 
-													LPCSTR ammoSect = NULL, 
-													u32 ParentID = 0xffffffff);
+	virtual void			OnMagazineEmpty();
+	void			SpawnAmmo(u32 boxCurr = 0xffffffff,
+		LPCSTR ammoSect = NULL,
+		u32 ParentID = 0xffffffff);
 
 	//  [8/3/2005]
-	virtual	float			Get_PDM_Base		()	const	{ return m_fPDM_disp_base			; };
-	virtual	float			Get_PDM_Vel_F		()	const	{ return m_fPDM_disp_vel_factor		; };
-	virtual	float			Get_PDM_Accel_F		()	const	{ return m_fPDM_disp_accel_factor	; };
-	virtual	float			Get_PDM_Crouch		()	const	{ return m_fPDM_disp_crouch			; };
-	virtual	float			Get_PDM_Crouch_NA	()	const	{ return m_fPDM_disp_crouch_no_acc	; };
+	virtual	float			Get_PDM_Base()	const { return m_fPDM_disp_base; };
+	virtual	float			Get_PDM_Vel_F()	const { return m_fPDM_disp_vel_factor; };
+	virtual	float			Get_PDM_Accel_F()	const { return m_fPDM_disp_accel_factor; };
+	virtual	float			Get_PDM_Crouch()	const { return m_fPDM_disp_crouch; };
+	virtual	float			Get_PDM_Crouch_NA()	const { return m_fPDM_disp_crouch_no_acc; };
 	//  [8/3/2005]
 protected:
 	int						iAmmoElapsed;		// ammo in magazine, currently
@@ -490,13 +492,13 @@ protected:
 	mutable int				iAmmoCurrent;
 	mutable u32				m_dwAmmoCurrentCalcFrame;	//кадр на котором просчитали кол-во патронов
 
-	virtual bool			IsNecessaryItem	    (const shared_str& item_sect);
+	virtual bool			IsNecessaryItem(const shared_str& item_sect);
 
 public:
 	xr_vector<shared_str>	m_ammoTypes;
 	xr_vector<shared_str>	m_highlightAddons;
 
-	CWeaponAmmo*			m_pAmmo;
+	CWeaponAmmo* m_pAmmo;
 	u32						m_ammoType;
 	BOOL					m_bHasTracers;
 	u8						m_u8TracerColorID;
@@ -506,10 +508,10 @@ public:
 	CCartridge				m_DefaultCartridge;
 	float					m_fCurrentCartirdgeDisp;
 
-		bool				unlimited_ammo				();
-	IC	bool				can_be_strapped				() const {return m_can_be_strapped;};
+	bool				unlimited_ammo();
+	IC	bool				can_be_strapped() const { return m_can_be_strapped; };
 
-	LPCSTR					GetCurrentAmmo_ShortName	();
+	LPCSTR					GetCurrentAmmo_ShortName();
 	float					GetMagazineWeight(const decltype(m_magazine)& mag) const;
 
 
@@ -518,8 +520,8 @@ protected:
 	u32						m_ef_weapon_type;
 
 public:
-	virtual u32				ef_main_weapon_type	() const;
-	virtual u32				ef_weapon_type		() const;
+	virtual u32				ef_main_weapon_type() const;
+	virtual u32				ef_weapon_type() const;
 
 protected:
 	// This is because when scope is attached we can't ask scope for these params
@@ -537,18 +539,18 @@ protected:
 	bool m_nearwall_on = false;
 
 public:
-	virtual	void			modify_holder_params		(float &range, float &fov) const;
-	virtual bool			use_crosshair				()	const {return true;}
-			bool			show_crosshair				();
-			bool			show_indicators				();
-	virtual BOOL			ParentMayHaveAimBullet		();
-	virtual BOOL			ParentIsActor				();
+	virtual	void			modify_holder_params(float& range, float& fov) const;
+	virtual bool			use_crosshair()	const { return true; }
+	bool			show_crosshair();
+	bool			show_indicators();
+	virtual BOOL			ParentMayHaveAimBullet();
+	virtual BOOL			ParentIsActor();
 
 private:
 	float					m_hit_probability[egdCount];
 
 public:
-	const float				&hit_probability			() const;
+	const float& hit_probability() const;
 	void					UpdateWeaponParams();
 	void UpdateSecondVP(); //
 	float GetZRotatingFactor() const { return m_fZoomRotationFactor; } //--#SM+#--
@@ -559,3 +561,4 @@ public:
 	virtual void OnBulletHit();
 	bool IsPartlyReloading();
 };
+ 

--- a/ogsr_engine/xrGame/Weapon.h
+++ b/ogsr_engine/xrGame/Weapon.h
@@ -29,87 +29,87 @@ constexpr float def_min_zoom_k = 0.3f;
 constexpr float def_zoom_step_count = 4.0f;
 
 class CWeapon : public CHudItemObject,
-	public CShootingObject
+				public CShootingObject
 {
 	friend class CWeaponScript;
 private:
 	typedef CHudItemObject inherited;
 
 public:
-	CWeapon(LPCSTR name);
-	virtual					~CWeapon();
+							CWeapon				(LPCSTR name);
+	virtual					~CWeapon			();
 
 	// Generic
-	virtual void			Load(LPCSTR section);
+	virtual void			Load				(LPCSTR section);
 
-	virtual BOOL			net_Spawn(CSE_Abstract* DC);
-	virtual void			net_Destroy();
-	virtual void			net_Export(NET_Packet& P);
-	virtual void			net_Import(NET_Packet& P);
-
-	virtual CWeapon* cast_weapon() { return this; }
-	virtual CWeaponMagazined* cast_weapon_magazined() { return 0; }
+	virtual BOOL			net_Spawn			(CSE_Abstract* DC);
+	virtual void			net_Destroy			();
+	virtual void			net_Export			(NET_Packet& P);
+	virtual void			net_Import			(NET_Packet& P);
+	
+	virtual CWeapon			*cast_weapon			()					{return this;}
+	virtual CWeaponMagazined*cast_weapon_magazined	()					{return 0;}
 
 
 	//serialization
-	virtual void			save(NET_Packet& output_packet);
-	virtual void			load(IReader& input_packet);
-	virtual BOOL			net_SaveRelevant() { return inherited::net_SaveRelevant(); }
+	virtual void			save				(NET_Packet &output_packet);
+	virtual void			load				(IReader &input_packet);
+	virtual BOOL			net_SaveRelevant	()								{return inherited::net_SaveRelevant();}
 
-	virtual void			UpdateCL();
-	virtual void			shedule_Update(u32 dt);
+	virtual void			UpdateCL			();
+	virtual void			shedule_Update		(u32 dt);
 
-	virtual void			renderable_Render();
-	virtual void			OnDrawUI();
-	virtual bool			need_renderable();
+	virtual void			renderable_Render	();
+	virtual void			OnDrawUI			();
+	virtual bool			need_renderable		();
 
-	virtual void			OnH_B_Chield();
-	virtual void			OnH_A_Chield();
-	virtual void			OnH_B_Independent(bool just_before_destroy);
-	virtual void			OnH_A_Independent();
-	virtual void			OnEvent(NET_Packet& P, u16 type);// {inherited::OnEvent(P,type);}
+	virtual void			OnH_B_Chield		();
+	virtual void			OnH_A_Chield		();
+	virtual void			OnH_B_Independent	(bool just_before_destroy);
+	virtual void			OnH_A_Independent	();
+	virtual void			OnEvent				(NET_Packet& P, u16 type);// {inherited::OnEvent(P,type);}
 
-	virtual	void			Hit(SHit* pHDS);
+	virtual	void			Hit					(SHit* pHDS);
 
-	virtual void			reinit();
-	virtual void			reload(LPCSTR section);
-	virtual void			create_physic_shell();
+	virtual void			reinit				();
+	virtual void			reload				(LPCSTR section);
+	virtual void			create_physic_shell	();
 	virtual void			activate_physic_shell();
-	virtual void			setup_physic_shell();
+	virtual void			setup_physic_shell	();
 
-	virtual void			SwitchState(u32 S);
-	virtual bool			Activate(bool = false);
+	virtual void			SwitchState			(u32 S);
+	virtual bool			Activate( bool = false );
 
-	virtual void			Hide(bool = false);
-	virtual void			Show(bool = false);
+	virtual void			Hide( bool = false );
+	virtual void			Show( bool = false );
 
 	//инициализация если вещь в активном слоте или спрятана на OnH_B_Chield
-	virtual void			OnActiveItem();
-	virtual void			OnHiddenItem();
+	virtual void			OnActiveItem		();
+	virtual void			OnHiddenItem		();
 
 	// Callback function added by Cribbledirge.
 	virtual IC void	StateSwitchCallback(GameObject::ECallbackType actor_type, GameObject::ECallbackType npc_type);
 
-	//////////////////////////////////////////////////////////////////////////
-	//  Network
-	//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+//  Network
+//////////////////////////////////////////////////////////////////////////
 
 public:
-	virtual bool			can_kill() const;
-	virtual CInventoryItem* can_kill(CInventory* inventory) const;
-	virtual const CInventoryItem* can_kill(const xr_vector<const CGameObject*>& items) const;
-	virtual bool			ready_to_kill() const;
+	virtual bool			can_kill			() const;
+	virtual CInventoryItem	*can_kill			(CInventory *inventory) const;
+	virtual const CInventoryItem *can_kill		(const xr_vector<const CGameObject*> &items) const;
+	virtual bool			ready_to_kill		() const;
 
-	//////////////////////////////////////////////////////////////////////////
-	//  Animation 
-	//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+//  Animation 
+//////////////////////////////////////////////////////////////////////////
 public:
 
-	void					signal_HideComplete();
+	void					signal_HideComplete	();
 
-	//////////////////////////////////////////////////////////////////////////
-	//  InventoryItem methods
-	//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+//  InventoryItem methods
+//////////////////////////////////////////////////////////////////////////
 public:
 	virtual bool			Action(s32 cmd, u32 flags);
 
@@ -125,28 +125,28 @@ public:
 		eMagEmpty,
 		eSwitch,
 	};
-	enum EWeaponSubStates {
-		eSubstateReloadBegin = 0,
+	enum EWeaponSubStates{
+		eSubstateReloadBegin		=0,
 		eSubstateReloadInProcess,
 		eSubstateReloadEnd,
 		eSubstateIdleMoving,
 		eSubstateIdleSprint,
 	};
 
-	virtual bool			IsHidden()	const { return GetState() == eHidden; }						// Does weapon is in hidden state
-	virtual bool			IsHiding()	const { return GetState() == eHiding; }
-	virtual bool			IsShowing()	const { return GetState() == eShowing; }
+	virtual bool			IsHidden			()	const		{	return GetState() == eHidden;}						// Does weapon is in hidden state
+	virtual bool			IsHiding			()	const		{	return GetState() == eHiding;}
+	virtual bool			IsShowing			()	const		{	return GetState() == eShowing;}
 
-	IC BOOL					IsValid()	const { return iAmmoElapsed; }
+	IC BOOL					IsValid				()	const		{	return iAmmoElapsed;						}
 	// Does weapon need's update?
-	BOOL					IsUpdating();
+	BOOL					IsUpdating			();
 
 
-	BOOL					IsMisfire() const;
-	BOOL					CheckForMisfire();
+	BOOL					IsMisfire			() const;
+	BOOL					CheckForMisfire		();
 
-	bool					IsTriStateReload() const { return m_bTriStateReload; }
-	EWeaponSubStates		GetReloadState() const { return (EWeaponSubStates)m_sub_state; }
+	bool					IsTriStateReload	() const		{ return m_bTriStateReload;}
+	EWeaponSubStates		GetReloadState		() const		{ return (EWeaponSubStates)m_sub_state;}
 	u8 idle_state();
 protected:
 	bool					m_bTriStateReload;
@@ -155,20 +155,20 @@ protected:
 	// Weapon fires now
 	bool					bWorking2;
 	// a misfire happens, you'll need to rearm weapon
-	bool					bMisfire;
+	bool					bMisfire;				
 
-	//////////////////////////////////////////////////////////////////////////
-	//  Weapon Addons
-	//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+//  Weapon Addons
+//////////////////////////////////////////////////////////////////////////
 public:
 	///////////////////////////////////////////
 	// работа с аддонами к оружию
 	//////////////////////////////////////////
 
 
-	bool IsGrenadeLauncherAttached() const;
-	bool IsScopeAttached() const;
-	bool IsSilencerAttached() const;
+			bool IsGrenadeLauncherAttached	() const;
+			bool IsScopeAttached			() const;
+			bool IsSilencerAttached			() const;
 
 	bool			IsGrenadeMode() const;
 
@@ -178,31 +178,31 @@ public:
 	virtual bool UseScopeTexture();
 
 	//обновление видимости для косточек аддонов
-	void UpdateAddonsVisibility();
-	void UpdateHUDAddonsVisibility();
+			void UpdateAddonsVisibility();
+			void UpdateHUDAddonsVisibility();
 	//инициализация свойств присоединенных аддонов
 	virtual void InitAddons();
 
 	//для отоброажения иконок апгрейдов в интерфейсе
-	int	GetScopeX() { return m_iScopeX; }
-	int	GetScopeY() { return m_iScopeY; }
-	int	GetSilencerX() { return m_iSilencerX; }
-	int	GetSilencerY() { return m_iSilencerY; }
-	int	GetGrenadeLauncherX() { return m_iGrenadeLauncherX; }
-	int	GetGrenadeLauncherY() { return m_iGrenadeLauncherY; }
+	int	GetScopeX() {return m_iScopeX;}
+	int	GetScopeY() {return m_iScopeY;}
+	int	GetSilencerX() {return m_iSilencerX;}
+	int	GetSilencerY() {return m_iSilencerY;}
+	int	GetGrenadeLauncherX() {return m_iGrenadeLauncherX;}
+	int	GetGrenadeLauncherY() {return m_iGrenadeLauncherY;}
 
-	const shared_str& GetGrenadeLauncherName() const { return m_sGrenadeLauncherName; }
-	const shared_str& GetScopeName() const { return m_sScopeName; }
-	const shared_str& GetSilencerName() const { return m_sSilencerName; }
+	const shared_str& GetGrenadeLauncherName	() const		{return m_sGrenadeLauncherName;}
+	const shared_str& GetScopeName				() const		{return m_sScopeName;}
+	const shared_str& GetSilencerName			() const		{return m_sSilencerName;}
 
-	u8		GetAddonsState()		const { return m_flagsAddOnState; };
-	void	SetAddonsState(u8 st) { m_flagsAddOnState = st; }//dont use!!! for buy menu only!!!
+	u8		GetAddonsState						()		const		{return m_flagsAddOnState;};
+	void	SetAddonsState						(u8 st)	{m_flagsAddOnState=st;}//dont use!!! for buy menu only!!!
 
-																			   //названия секций подключаемых аддонов
-	shared_str		m_sScopeName;
-	std::vector<shared_str> m_allScopeNames;
-	shared_str		m_sSilencerName;
-	shared_str		m_sGrenadeLauncherName;
+                                                                               //названия секций подключаемых аддонов
+    shared_str		m_sScopeName;
+    std::vector<shared_str> m_allScopeNames;
+    shared_str		m_sSilencerName;
+    shared_str		m_sGrenadeLauncherName;
 
 	shared_str m_sWpn_scope_bone;
 	shared_str m_sWpn_silencer_bone;
@@ -229,10 +229,10 @@ protected:
 	int	m_iScopeX, m_iScopeY;
 	int	m_iSilencerX, m_iSilencerY;
 	int	m_iGrenadeLauncherX, m_iGrenadeLauncherY;
-
-	///////////////////////////////////////////////////
-	//	для режима приближения и снайперского прицела
-	///////////////////////////////////////////////////
+		
+///////////////////////////////////////////////////
+//	для режима приближения и снайперского прицела
+///////////////////////////////////////////////////
 protected:
 	//разрешение регулирования приближения. Real Wolf.
 	bool			m_bScopeDynamicZoom;
@@ -245,7 +245,7 @@ protected:
 	//время приближения
 	float			m_fZoomRotateTime;
 	//текстура для снайперского прицела, в режиме приближения
-	CUIStaticItem* m_UIScope;
+	CUIStaticItem*	m_UIScope;
 	//коэффициент увеличения прицеливания
 	float			m_fIronSightZoomFactor;
 	//коэффициент увеличения прицела
@@ -268,26 +268,26 @@ protected:
 	//Целевой HUD FOV для линзы
 	float			m_fSecondVPHudFov;
 
-	bool m_bUseScopeZoom = false;
-	bool m_bUseScopeGrenadeZoom = false;
+	bool m_bUseScopeZoom			= false;
+	bool m_bUseScopeGrenadeZoom		= false;
 	bool m_bUseScopeDOF = true;
 	bool m_bForceScopeDOF = false;
 	bool m_bScopeShowIndicators = true;
 	bool m_bIgnoreScopeTexture = false;
 
-	float m_fMinZoomK = def_min_zoom_k;
-	float m_fZoomStepCount = def_zoom_step_count;
+	float m_fMinZoomK			= def_min_zoom_k;
+	float m_fZoomStepCount		= def_zoom_step_count;
 
 	float			m_fScopeInertionFactor;
 public:
 
-	IC bool					IsZoomEnabled()	const { return m_bZoomEnabled; }
-	void					GetZoomData(float scope_factor, float& delta, float& min_zoom_factor);
-	virtual	void			ZoomChange(bool inc);
-	virtual void			OnZoomIn();
-	virtual void			OnZoomOut();
-	bool			IsZoomed()	const { return m_bZoomMode; };
-	CUIStaticItem* ZoomTexture();
+	IC bool					IsZoomEnabled		()	const	{return m_bZoomEnabled;}
+	void					GetZoomData			(float scope_factor, float& delta, float& min_zoom_factor);
+	virtual	void			ZoomChange			(bool inc);
+	virtual void			OnZoomIn			();
+	virtual void			OnZoomOut			();
+			bool			IsZoomed			()	const	{return m_bZoomMode;};
+	CUIStaticItem*			ZoomTexture			();	
 	bool ZoomHideCrosshair()
 	{
 		auto* pA = smart_cast<CActor*>(H_Parent());
@@ -297,26 +297,26 @@ public:
 		return (m_bHideCrosshairInZoom || ZoomTexture()) && !psActorFlags.test(AF_CROSSHAIR_DBG);
 	}
 
-	virtual void			OnZoomChanged() {}
+	virtual void			OnZoomChanged		() {}
 
-	IC float				GetZoomFactor() const { return m_fZoomFactor; }
-	virtual	float			CurrentZoomFactor();
+	IC float				GetZoomFactor		() const		{	return m_fZoomFactor;	}
+	virtual	float			CurrentZoomFactor	();
 	//показывает, что оружие находится в соостоянии поворота для приближенного прицеливания
-	bool			IsRotatingToZoom() const { return (m_fZoomRotationFactor < 1.f); }
+			bool			IsRotatingToZoom	() const		{	return (m_fZoomRotationFactor<1.f);}
 
-	virtual float			Weight() const;
-	virtual u32				Cost() const;
+	virtual float			Weight				() const;		
+	virtual u32				Cost				() const;
 	virtual float			GetControlInertionFactor() const;
 
 public:
-	virtual EHandDependence		HandDependence()	const { return eHandDependence; }
-	bool				IsSingleHanded()	const { return m_bIsSingleHanded; }
+    virtual EHandDependence		HandDependence		()	const		{	return eHandDependence;}
+			bool				IsSingleHanded		()	const		{	return m_bIsSingleHanded; }
 
 public:
-	IC		LPCSTR			strap_bone0() const { return m_strap_bone0; }
-	IC		LPCSTR			strap_bone1() const { return m_strap_bone1; }
-	IC		void			strapped_mode(bool value) { m_strapped_mode = value; }
-	IC		bool			strapped_mode() const { return m_strapped_mode; }
+	IC		LPCSTR			strap_bone0			() const {return m_strap_bone0;}
+	IC		LPCSTR			strap_bone1			() const {return m_strap_bone1;}
+	IC		void			strapped_mode		(bool value) {m_strapped_mode = value;}
+	IC		bool			strapped_mode		() const {return m_strapped_mode;}
 
 protected:
 	LPCSTR					m_strap_bone0;
@@ -338,70 +338,70 @@ private:
 	firedeps				m_current_firedeps{};
 
 protected:
-	virtual void			UpdateFireDependencies_internal();
-	virtual void			UpdatePosition(const Fmatrix& transform);	//.
-	virtual void			UpdateXForm();
+	virtual void			UpdateFireDependencies_internal	();
+	virtual void			UpdatePosition			(const Fmatrix& transform);	//.
+	virtual void			UpdateXForm				();
 
 	float					m_fLR_MovingFactor; // !!!!
 	float					m_fFB_MovingFactor;
 	float					m_longitudinal_offset[6];
 	Fvector					m_strafe_offset[3][2]; //pos,rot,data/ normal,aim-GL --#SM+#--
 
-	virtual	u8				GetCurrentHudOffsetIdx() override;
-	virtual bool			MovingAnimAllowedNow();
-	virtual void			UpdateHudAdditonal(Fmatrix&);
-	virtual bool			IsHudModeNow();
+	virtual	u8				GetCurrentHudOffsetIdx	() override;
+	virtual bool			MovingAnimAllowedNow	();
+	virtual void			UpdateHudAdditonal		(Fmatrix&);
+	virtual bool			IsHudModeNow			();
 
-	IC		void			UpdateFireDependencies() { if (dwFP_Frame == Device.dwFrame) return; UpdateFireDependencies_internal(); };
+	IC		void			UpdateFireDependencies	()			{ if (dwFP_Frame==Device.dwFrame) return; UpdateFireDependencies_internal(); };
 
-	virtual void			LoadFireParams(LPCSTR section, LPCSTR prefix);
-public:
-	IC		const Fvector& get_LastFP() { UpdateFireDependencies(); return m_current_firedeps.vLastFP; }
-	IC		const Fvector& get_LastFP2() { UpdateFireDependencies(); return m_current_firedeps.vLastFP2; }
-	IC		const Fvector& get_LastFD() { UpdateFireDependencies(); return m_current_firedeps.vLastFD; }
-	IC		const Fvector& get_LastSP() { UpdateFireDependencies(); return m_current_firedeps.vLastSP; }
+	virtual void			LoadFireParams		(LPCSTR section, LPCSTR prefix);
+public:	
+	IC		const Fvector&	get_LastFP				()			{ UpdateFireDependencies(); return m_current_firedeps.vLastFP;	}
+	IC		const Fvector&	get_LastFP2				()			{ UpdateFireDependencies(); return m_current_firedeps.vLastFP2;	}
+	IC		const Fvector&	get_LastFD				()			{ UpdateFireDependencies(); return m_current_firedeps.vLastFD;	}
+	IC		const Fvector&	get_LastSP				()			{ UpdateFireDependencies(); return m_current_firedeps.vLastSP;	}
 
-	virtual const Fvector& get_CurrentFirePoint() { return get_LastFP(); }
-	virtual const Fvector& get_CurrentFirePoint2() { return get_LastFP2(); }
-	virtual const Fmatrix& get_ParticlesXFORM() { UpdateFireDependencies(); return m_current_firedeps.m_FireParticlesXForm; }
+	virtual const Fvector&	get_CurrentFirePoint	()			{ return get_LastFP();				}
+	virtual const Fvector&	get_CurrentFirePoint2	()			{ return get_LastFP2();				}
+	virtual const Fmatrix&	get_ParticlesXFORM		()			{ UpdateFireDependencies(); return m_current_firedeps.m_FireParticlesXForm;	}
 	virtual void			ForceUpdateFireParticles();
 
 	//////////////////////////////////////////////////////////////////////////
 	// Weapon fire
 	//////////////////////////////////////////////////////////////////////////
 protected:
-	virtual void			SetDefaults();
+	virtual void			SetDefaults			();
 
 	//трассирование полета пули
-	virtual void			FireTrace(const Fvector& P, const Fvector& D);
-	virtual float			GetWeaponDeterioration();
+	virtual void			FireTrace			(const Fvector& P, const Fvector& D);
+	virtual float			GetWeaponDeterioration	();
 
-	virtual void			FireStart() { CShootingObject::FireStart(); }
-	virtual void			FireEnd();// {CShootingObject::FireEnd();}
+	virtual void			FireStart			() {CShootingObject::FireStart();}
+	virtual void			FireEnd				();// {CShootingObject::FireEnd();}
 
-	virtual void			Fire2Start();
-	virtual void			Fire2End();
-	virtual void			Reload();
-	void			StopShooting();
-
+	virtual void			Fire2Start			();
+	virtual void			Fire2End			();
+	virtual void			Reload				();
+			void			StopShooting		();
+    
 
 	// обработка визуализации выстрела
-	virtual void			OnShot() {};
-	virtual void			AddShotEffector();
-	virtual void			RemoveShotEffector();
-	virtual	void			ClearShotEffector();
+	virtual void			OnShot				(){};
+	virtual void			AddShotEffector		();
+	virtual void			RemoveShotEffector	();
+	virtual	void			ClearShotEffector	();
 
 public:
 	//текущая дисперсия (в радианах) оружия с учетом используемого патрона
-	float					GetFireDispersion(bool with_cartridge);
-	float					GetFireDispersion(float cartridge_k);
-	//	const Fvector&			GetRecoilDeltaAngle	();
-	virtual	int				ShotsFired() { return 0; }
+	float					GetFireDispersion	(bool with_cartridge)			;
+	float					GetFireDispersion	(float cartridge_k)				;
+//	const Fvector&			GetRecoilDeltaAngle	();
+	virtual	int				ShotsFired			() { return 0; }
 
 	//параметы оружия в зависимоти от его состояния исправности
-	float					GetConditionDispersionFactor() const;
-	float					GetConditionMisfireProbability() const;
-	virtual	float			GetConditionToShow() const;
+	float					GetConditionDispersionFactor	() const;
+	float					GetConditionMisfireProbability	() const;
+	virtual	float			GetConditionToShow				() const;
 
 public:
 	//отдача при стрельбе 
@@ -427,11 +427,11 @@ protected:
 	float					conditionDecreasePerShotSilencer;
 
 	//  [8/2/2005]
-	float					m_fPDM_disp_base;
-	float					m_fPDM_disp_vel_factor;
-	float					m_fPDM_disp_accel_factor;
-	float					m_fPDM_disp_crouch;
-	float					m_fPDM_disp_crouch_no_acc;
+	float					m_fPDM_disp_base			;
+	float					m_fPDM_disp_vel_factor		;
+	float					m_fPDM_disp_accel_factor	;
+	float					m_fPDM_disp_crouch			;
+	float					m_fPDM_disp_crouch_no_acc	;
 	//  [8/2/2005]
 
 protected:
@@ -443,46 +443,46 @@ protected:
 	float					m_fMinRadius;
 	float					m_fMaxRadius;
 
-	//////////////////////////////////////////////////////////////////////////
-	// партиклы
-	//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+// партиклы
+//////////////////////////////////////////////////////////////////////////
 
-protected:
+protected:	
 	//для второго ствола
-	void			StartFlameParticles2();
-	void			StopFlameParticles2();
-	void			UpdateFlameParticles2();
+			void			StartFlameParticles2();
+			void			StopFlameParticles2	();
+			void			UpdateFlameParticles2();
 protected:
 	shared_str					m_sFlameParticles2;
 	//объект партиклов для стрельбы из 2-го ствола
-	CParticlesObject* m_pFlameParticles2;
+	CParticlesObject*		m_pFlameParticles2;
 
-	//////////////////////////////////////////////////////////////////////////
-	// Weapon and ammo
-	//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+// Weapon and ammo
+//////////////////////////////////////////////////////////////////////////
 protected:
-	int GetAmmoCount_forType(shared_str const& ammo_type, u32 = 0) const;
-	int GetAmmoCount(u8 ammo_type, u32 = 0) const;
+	int GetAmmoCount_forType( shared_str const& ammo_type, u32 = 0 ) const;
+	int GetAmmoCount( u8 ammo_type, u32 = 0 ) const;
 
 public:
-	IC int					GetAmmoElapsed()	const { return /*int(m_magazine.size())*/iAmmoElapsed; }
-	IC int					GetAmmoMagSize()	const { return iMagazineSize; }
-	int						GetAmmoCurrent(bool use_item_to_spawn = false)  const;
-	IC void					SetAmmoMagSize(int _size) { iMagazineSize = _size; }
+	IC int					GetAmmoElapsed		()	const		{	return /*int(m_magazine.size())*/iAmmoElapsed;}
+	IC int					GetAmmoMagSize		()	const		{	return iMagazineSize;						}
+	int						GetAmmoCurrent		(bool use_item_to_spawn = false)  const;
+	IC void					SetAmmoMagSize		(int _size) { iMagazineSize = _size; }
 
-	void					SetAmmoElapsed(int ammo_count);
+	void					SetAmmoElapsed		(int ammo_count);
 
-	virtual void			OnMagazineEmpty();
-	void			SpawnAmmo(u32 boxCurr = 0xffffffff,
-		LPCSTR ammoSect = NULL,
-		u32 ParentID = 0xffffffff);
+	virtual void			OnMagazineEmpty		();
+			void			SpawnAmmo			(u32 boxCurr = 0xffffffff, 
+													LPCSTR ammoSect = NULL, 
+													u32 ParentID = 0xffffffff);
 
 	//  [8/3/2005]
-	virtual	float			Get_PDM_Base()	const { return m_fPDM_disp_base; };
-	virtual	float			Get_PDM_Vel_F()	const { return m_fPDM_disp_vel_factor; };
-	virtual	float			Get_PDM_Accel_F()	const { return m_fPDM_disp_accel_factor; };
-	virtual	float			Get_PDM_Crouch()	const { return m_fPDM_disp_crouch; };
-	virtual	float			Get_PDM_Crouch_NA()	const { return m_fPDM_disp_crouch_no_acc; };
+	virtual	float			Get_PDM_Base		()	const	{ return m_fPDM_disp_base			; };
+	virtual	float			Get_PDM_Vel_F		()	const	{ return m_fPDM_disp_vel_factor		; };
+	virtual	float			Get_PDM_Accel_F		()	const	{ return m_fPDM_disp_accel_factor	; };
+	virtual	float			Get_PDM_Crouch		()	const	{ return m_fPDM_disp_crouch			; };
+	virtual	float			Get_PDM_Crouch_NA	()	const	{ return m_fPDM_disp_crouch_no_acc	; };
 	//  [8/3/2005]
 protected:
 	int						iAmmoElapsed;		// ammo in magazine, currently
@@ -492,13 +492,13 @@ protected:
 	mutable int				iAmmoCurrent;
 	mutable u32				m_dwAmmoCurrentCalcFrame;	//кадр на котором просчитали кол-во патронов
 
-	virtual bool			IsNecessaryItem(const shared_str& item_sect);
+	virtual bool			IsNecessaryItem	    (const shared_str& item_sect);
 
 public:
 	xr_vector<shared_str>	m_ammoTypes;
 	xr_vector<shared_str>	m_highlightAddons;
 
-	CWeaponAmmo* m_pAmmo;
+	CWeaponAmmo*			m_pAmmo;
 	u32						m_ammoType;
 	BOOL					m_bHasTracers;
 	u8						m_u8TracerColorID;
@@ -508,10 +508,10 @@ public:
 	CCartridge				m_DefaultCartridge;
 	float					m_fCurrentCartirdgeDisp;
 
-	bool				unlimited_ammo();
-	IC	bool				can_be_strapped() const { return m_can_be_strapped; };
+		bool				unlimited_ammo				();
+	IC	bool				can_be_strapped				() const {return m_can_be_strapped;};
 
-	LPCSTR					GetCurrentAmmo_ShortName();
+	LPCSTR					GetCurrentAmmo_ShortName	();
 	float					GetMagazineWeight(const decltype(m_magazine)& mag) const;
 
 
@@ -520,8 +520,8 @@ protected:
 	u32						m_ef_weapon_type;
 
 public:
-	virtual u32				ef_main_weapon_type() const;
-	virtual u32				ef_weapon_type() const;
+	virtual u32				ef_main_weapon_type	() const;
+	virtual u32				ef_weapon_type		() const;
 
 protected:
 	// This is because when scope is attached we can't ask scope for these params
@@ -539,18 +539,18 @@ protected:
 	bool m_nearwall_on = false;
 
 public:
-	virtual	void			modify_holder_params(float& range, float& fov) const;
-	virtual bool			use_crosshair()	const { return true; }
-	bool			show_crosshair();
-	bool			show_indicators();
-	virtual BOOL			ParentMayHaveAimBullet();
-	virtual BOOL			ParentIsActor();
+	virtual	void			modify_holder_params		(float &range, float &fov) const;
+	virtual bool			use_crosshair				()	const {return true;}
+			bool			show_crosshair				();
+			bool			show_indicators				();
+	virtual BOOL			ParentMayHaveAimBullet		();
+	virtual BOOL			ParentIsActor				();
 
 private:
 	float					m_hit_probability[egdCount];
 
 public:
-	const float& hit_probability() const;
+	const float				&hit_probability			() const;
 	void					UpdateWeaponParams();
 	void UpdateSecondVP(); //
 	float GetZRotatingFactor() const { return m_fZoomRotationFactor; } //--#SM+#--
@@ -561,4 +561,3 @@ public:
 	virtual void OnBulletHit();
 	bool IsPartlyReloading();
 };
- 


### PR DESCRIPTION
По примеру стрейфов сделал смещение оружия при передвижении вперёд/назад. 

Чтобы включить эту фичу, нужно в external.ltx прописать `default_longitudinal_offset_enabled = true` . В нём же можно указать глобальный параметр смещения для всего оружия с помощью `default_longitudinal_hud_offset` (по стандарту 0.04).

Видео с демонстрацией: https://youtu.be/pJlgefFIOJI

Список доступных параметров для настройки отдельных оружий (добавлять в секцию оружия):
`longitudinal_hud_offset` - фактор смещения оружия во время передвижения вперёд/назад (по стандарту 0.04)
`longitudinal_hud_offset_aim` - то же самое что и выше, но для режима прицеливания
`longitudinal_transition_time` - скорость смещения (по стандарту 0.18)
`longitudinal_transition_time_aim` - ну вы поняли. 
`longitudinal_offset_enabled` - false - выключить смещение, true - включить
`longitudinal_offset_aim_enabled` - ^ для режима прицеливания
**Они необязательны, если вас устраивает глобальная настройка  указанная в external.ltx**

P.S я сломал диффы, но они работают со включенным "Hide whitespace changes"