### PR TITLE
Доработка Luabind

### DIFF
--- a/ogsr_engine/Luabind/luabind/operator.hpp
+++ b/ogsr_engine/Luabind/luabind/operator.hpp
@@ -290,10 +290,17 @@ namespace luabind {
     }
 
     template<class T>
-    T const& tostring_operator(T const& x)
+    string tostring_operator(T const& x)
     {
-        return x;
-    };
+#ifdef LUABIND_NO_STRINGSTREAM
+        std::strstream s;
+        s << x << std::ends;
+#else
+        std::stringstream s;
+        s << x;
+#endif
+        return s.str();
+    }
     
     LUABIND_UNARY_OPERATOR(tostring, tostring_operator, tostring)
     LUABIND_UNARY_OPERATOR(unm, -, operator-)

--- a/ogsr_engine/Luabind/src/class_rep.cpp
+++ b/ogsr_engine/Luabind/src/class_rep.cpp
@@ -403,8 +403,22 @@ int luabind::detail::class_rep::operator_dispatcher(lua_State* L)
 		}
 	}
 
+	object_rep* obj = static_cast<object_rep*>(lua_touserdata(L, 1));
+	class_rep* crep = obj->crep();
+
+	//Дефолтный __tostring
+	auto ptr = lua_tostring(L, lua_upvalueindex(1));
+	if (ptr && std::strcmp(ptr, "__tostring") == 0)
+	{
+		lua_pop(L, lua_gettop(L));
+		lua_pushstring(L, crep->name());
+		return 1;
+	}
+
 	lua_pop(L, lua_gettop(L));
-	lua_pushstring(L, "No such operator defined");
+	string512 err_str;
+	xr_sprintf(err_str, "! No such operator [%s] defined in class [%s]", ptr, crep->name());
+	lua_pushstring(L, err_str);
 	lua_error(L);
 
 	return 0;


### PR DESCRIPTION
Исправлен сломанный оператор __tostring - перегрузка не работала.
Добавлен дефолтный __tostring для объектов класса, выводящий имя класса.
Добавлен подробный лог ошибки отсутствия оператора - "No such operator [%s] defined in class [%s]"