### PR TITLE
Правки и фитчи диалогов и худа

### DIFF
--- a/ogsr_engine/xrGame/PhraseDialog.cpp
+++ b/ogsr_engine/xrGame/PhraseDialog.cpp
@@ -112,7 +112,8 @@ bool CPhraseDialog::SayPhrase(DIALOG_SHARED_PTR& phrase_dialog, const shared_str
             }
         }
 
-        R_ASSERT2(!phrase_dialog->m_PhraseVector.empty(), make_string("No available phrase to say, dialog[%s]", *phrase_dialog->m_DialogId));
+        if (phrase_dialog->m_PhraseVector.empty()) 
+			return !(phrase_dialog->m_bFinished = true);
 
         //упорядочить списко по убыванию благосклонности
         std::sort(phrase_dialog->m_PhraseVector.begin(), phrase_dialog->m_PhraseVector.end(), PhraseGoodwillPred);

--- a/ogsr_engine/xrGame/Weapon.cpp
+++ b/ogsr_engine/xrGame/Weapon.cpp
@@ -670,6 +670,12 @@ BOOL CWeapon::net_Spawn(CSE_Abstract* DC)
 
     VERIFY((u32)iAmmoElapsed == m_magazine.size());
 
+    if (m_pPhysicsShell)
+    {
+        float frc = 5.f * EffectiveGravity() * m_pPhysicsShell->getMass();
+        m_pPhysicsShell->applyForce(frc, frc*0.5, 0.f);
+    }
+
     return bResult;
 }
 

--- a/ogsr_engine/xrGame/ui/UIMainIngameWnd.cpp
+++ b/ogsr_engine/xrGame/ui/UIMainIngameWnd.cpp
@@ -151,6 +151,7 @@ void CUIMainIngameWnd::Init()
 
     UIWeaponBack.AttachChild(&UIWeaponIcon);
     xml_init.InitStatic(uiXml, "static_wpn_icon", 0, &UIWeaponIcon);
+    static_wpn_icon_scale = uiXml.ReadAttribFlt("static_wpn_icon", 0, "scale", 1.0);
     UIWeaponIcon.SetShader(GetEquipmentIconsShader());
     UIWeaponIcon_rect = UIWeaponIcon.GetWndRect();
     //---------------------------------------------------------
@@ -321,8 +322,8 @@ void CUIMainIngameWnd::SetAmmoIcon(const shared_str& sect_name)
 
     float iGridWidth = icon_params.grid_width;
 
-    float w = std::clamp(iGridWidth, 1.f, 2.f) * INV_GRID_WIDTH;
-    float h = INV_GRID_HEIGHT;
+    float w = std::clamp(iGridWidth, 1.f, 2.f) * INV_GRID_WIDTH * static_wpn_icon_scale;
+    float h = INV_GRID_HEIGHT * static_wpn_icon_scale;
     w *= UI()->get_current_kx();
 
     float x = UIWeaponIcon_rect.x1;

--- a/ogsr_engine/xrGame/ui/UIMainIngameWnd.h
+++ b/ogsr_engine/xrGame/ui/UIMainIngameWnd.h
@@ -145,6 +145,8 @@ protected:
     // Отображение подсказок при наведении прицела на объект
     void RenderQuickInfos();
 
+    float static_wpn_icon_scale = 1.f;
+
 public:
     CUICarPanel& CarPanel() { return UICarPanel; };
     CUIMotionIcon& MotionIcon() { return UIMotionIcon; }


### PR DESCRIPTION
Для мододелов фитча облегчающая жизнь: Если в диалоге не найдена следующая фраза, то вылета не будет, у собеседника строки фразы не будет, у ГГ будет 1 фраза "прощания" (в ванили "До встречи"). Особенно подойдет если переносите допотопные моды.

Теперь можно тегу `static_wpn_icon` (maingame(_16).xml) задать атрибут `scale` и масштабировать изображение пачки патронов. Раньше хоть какие значения пиши в ширину и высоту - размеры иконки жестко задавал движок.