### PR TITLE
Мелкие и важные правки по UI.

### DIFF
--- a/ogsr_engine/xrGame/ui/UIArtefactPanel.cpp
+++ b/ogsr_engine/xrGame/ui/UIArtefactPanel.cpp
@@ -9,7 +9,9 @@ void CUIArtefactPanel::InitFromXML(CUIXml& xml, LPCSTR path, int index)
     CUIXmlInit::InitWindow(xml, path, index, this);
     m_cell_size.x = xml.ReadAttribFlt(path, index, "cell_width");
     m_cell_size.y = xml.ReadAttribFlt(path, index, "cell_height");
-    m_fScale = xml.ReadAttribFlt(path, index, "scale");
+    m_fScale      = xml.ReadAttribFlt(path, index, "scale", 1);
+    m_iIndent     = xml.ReadAttribFlt(path, index, "indent", 1);
+    m_bVert       = xml.ReadAttribInt(path, index, "vert") == 1;
 }
 
 void CUIArtefactPanel::InitIcons(const TIItemContainer& artefacts)
@@ -29,7 +31,6 @@ void CUIArtefactPanel::InitIcons(const TIItemContainer& artefacts)
 
 void CUIArtefactPanel::Draw()
 {
-    const float iIndent = 1.0f;
     float x = 0.0f;
     float y = 0.0f;
     float iHeight;
@@ -52,7 +53,10 @@ void CUIArtefactPanel::Draw()
         m_si.SetRect(0, 0, iWidth, iHeight);
 
         m_si.SetPos(x, y);
-        x = x + iIndent + iWidth;
+        if (!m_bVert)
+            x = x + m_iIndent + iWidth;
+        else
+            y = y + m_iIndent + iHeight;
 
         m_si.Render();
     }

--- a/ogsr_engine/xrGame/ui/UIArtefactPanel.h
+++ b/ogsr_engine/xrGame/ui/UIArtefactPanel.h
@@ -18,6 +18,8 @@ public:
     void InitFromXML(CUIXml& xml, LPCSTR path, int index);
 
 protected:
+    bool m_bVert;
+    float m_iIndent;
     float m_fScale;
     Fvector2 m_cell_size;
     xr_vector<CIconParams*> m_vRects;

--- a/ogsr_engine/xrGame/ui/UIProgressBar.cpp
+++ b/ogsr_engine/xrGame/ui/UIProgressBar.cpp
@@ -10,6 +10,7 @@ CUIProgressBar::CUIProgressBar()
 
     m_bBackgroundPresent = false;
     m_bUseColor = false;
+    m_bUseMidColor = false;
     m_bUseGradient = true;
 
     AttachChild(&m_UIBackgroundItem);
@@ -55,7 +56,10 @@ void CUIProgressBar::UpdateProgressBar()
         if (m_bUseGradient)
         {
             Fcolor curr;
-            curr.lerp(m_minColor, m_middleColor, m_maxColor, fCurrentLength);
+            if (m_bUseMidColor)
+                curr.lerp(m_minColor, m_middleColor, m_maxColor, fCurrentLength);
+            else
+                curr.lerp(m_minColor, m_maxColor, fCurrentLength);
             m_UIProgressItem.SetTextureColor(curr.get());
         }
         else

--- a/ogsr_engine/xrGame/ui/UIProgressBar.h
+++ b/ogsr_engine/xrGame/ui/UIProgressBar.h
@@ -35,6 +35,7 @@ protected:
 
 public:
     bool m_bUseColor;
+    bool m_bUseMidColor;
     bool m_bUseGradient; // Alundaio: if false then use only solid color with m_maxColor
     Fcolor m_minColor;
     Fcolor m_middleColor;

--- a/ogsr_engine/xrGame/ui/UIXmlInit.cpp
+++ b/ogsr_engine/xrGame/ui/UIXmlInit.cpp
@@ -666,9 +666,12 @@ bool CUIXmlInit::InitProgressBar(CUIXml& xml_doc, LPCSTR path, int index, CUIPro
         pWnd->m_minColor.set(color);
 
         strconcat(sizeof(buf), buf, path, ":middle_color");
-
-        color = GetColor(xml_doc, buf, index, 0xff);
-        pWnd->m_middleColor.set(color);
+        if (xml_doc.NavigateToNode(buf, index))
+        {
+            pWnd->m_bUseMidColor = true;
+            color = GetColor(xml_doc, buf, index, 0xff);
+            pWnd->m_middleColor.set(color);
+        }
 
         strconcat(sizeof(buf), buf, path, ":max_color");
 


### PR DESCRIPTION
1. Для панели артефактов добавил возможность вертикального расположения и настройки промежутка между артефактами. Возможно, вертикальное расположение не нужно, и было бы проще использовать `SetHeading()`, но пусть будет так. Прикрепляю скриншоты, как это выглядит ингейм.
![image](https://user-images.githubusercontent.com/47980896/218337630-53cd67a8-4dd4-4899-ae2e-8cd0b7a3bd33.png)
![image](https://user-images.githubusercontent.com/47980896/218337637-379c67f2-204c-402a-adf7-634e3455ba53.png)
2. Важная правка по прогресс-барам, так как при оригинальной геймдате (отсутствие `middle_color` в XML) полоска состояния окрашивается в странный цвет. Прилагаю скриншоты на примере ЗП, где эта проблема тоже была.
Ванильный движок, но убран `middle_color`, нижний пбар без изменений: ![image](https://user-images.githubusercontent.com/47980896/218337815-2e78d64d-bc10-41a7-bf78-e5abf7ff4903.png)
Всё то же самое, но уже добавлено опциональное использование`middle_color`: 
![image](https://user-images.githubusercontent.com/47980896/218337918-bd22964c-bc23-4daf-ba49-e3248b6eeb1a.png)
К слову, удивлён, что с [fecbf04](https://github.com/OGSR/OGSR-Engine/commit/fecbf04d14e205faba29d88d6443a66d1de25a0f#diff-df8eefa2cb88038162e0f0be49a08e39f1caa60e52b4b84bfcc5921f861ef0ff) ещё никто не заметил проблемы с прогресс-барами, и что их поведение отличалось от ванильного.