### PR TITLE
Registration class `FS_Path` for Lua

### DIFF
--- a/ogsr_engine/xrGame/CarLights.cpp
+++ b/ogsr_engine/xrGame/CarLights.cpp
@@ -192,13 +192,20 @@ bool CCarLights::IsLight(u16 bone_id)
 }
 bool CCarLights::findLight(u16 bone_id, SCarLight*& light)
 {
-    LIGHTS_I i, e = m_lights.end();
     SCarLight find_light;
     find_light.bone_id = bone_id;
-    i = std::find_if(m_lights.begin(), e, SFindLightPredicate(&find_light));
-    light = *i;
-    return i != e; //-V783
+
+    auto e = m_lights.end();
+    auto i = std::find_if(m_lights.begin(), e, SFindLightPredicate(&find_light));
+    if (i != e)
+    {
+        light = *i;
+        return true;
+    }
+    else
+        return false;
 }
+
 CCarLights::~CCarLights()
 {
     LIGHTS_I i = m_lights.begin(), e = m_lights.end();

--- a/ogsr_engine/xrGame/fs_registrator_script.cpp
+++ b/ogsr_engine/xrGame/fs_registrator_script.cpp
@@ -279,8 +279,8 @@ void fs_registrator::script_register(lua_State* L)
 
               class_<FS_file_list>("FS_file_list").def("Size", &FS_file_list::Size).def("GetAt", &FS_file_list::GetAt).def("Free", &FS_file_list::Free),
 
-              /*		class_<FS_Path>("FS_Path")
-                          .def_readonly("m_Path",						&FS_Path::m_Path)
+              class_<FS_Path>("FS_Path"),
+              /*            .def_readonly("m_Path",						&FS_Path::m_Path)
                           .def_readonly("m_Root",						&FS_Path::m_Root)
                           .def_readonly("m_Add",						&FS_Path::m_Add)
                           .def_readonly("m_DefExt",					&FS_Path::m_DefExt)

--- a/ogsr_engine/xrGame/ui/UIInventoryUtilities.cpp
+++ b/ogsr_engine/xrGame/ui/UIInventoryUtilities.cpp
@@ -156,7 +156,6 @@ bool InventoryUtilities::FreeRoom_inBelt(TIItemContainer& item_list, PIItem _ite
                 }
             }
         }
-/*
         //разместить элемент на найденном месте
         if (found_place)
         {
@@ -168,7 +167,6 @@ bool InventoryUtilities::FreeRoom_inBelt(TIItemContainer& item_list, PIItem _ite
                 }
             }
         }
-*/
     }
     // remove
     item_list.erase(std::remove(item_list.begin(), item_list.end(), _item), item_list.end());


### PR DESCRIPTION
Некоторые методы экспортированные из `CLocatorAPI` в Lua (например `.def("get_path", &CLocatorAPI::get_path)`, метод `get_path`) возвращают экземпляры `FS_Path`, но Lua  "не понимает" этот тип и бросает ошибку. Я вернул регистрацию `FS_Path` для Lua, но без методов.